### PR TITLE
RDB 캐싱 및 Inflight Queue 스케쥴링 알고리즘 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ docker-compose.yaml
 .github/workflows/**
 **/src/main/resources/**
 **/src/test/resources/**
+
+build-and-push-latest.sh
+build-and-push.sh

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM gradle:8.5-jdk21 AS builder
+FROM --platform=linux/amd64 gradle:8.5-jdk21 AS builder
 
 WORKDIR /build
 
@@ -15,7 +15,7 @@ COPY app ./app
 RUN ./gradlew :app:bootJar --no-daemon
 
 # Runtime stage
-FROM eclipse-temurin:21-jre
+FROM --platform=linux/amd64 eclipse-temurin:21-jre
 
 WORKDIR /app
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,29 +1,10 @@
-# Build stage
-FROM --platform=linux/amd64 gradle:8.5-jdk21 AS builder
-
-WORKDIR /build
-
-# Copy gradle files
-COPY build.gradle settings.gradle gradlew ./
-COPY gradle ./gradle
-
-# Copy all modules (including common)
-COPY common ./common
-COPY app ./app
-
-# Build the application (common will be built as dependency)
-RUN ./gradlew :app:bootJar --no-daemon
-
-# Runtime stage
+# Runtime-only image. Build the jar locally before running docker build.
 FROM --platform=linux/amd64 eclipse-temurin:21-jre
 
 WORKDIR /app
 
-# Copy the built jar from builder
-COPY --from=builder /build/app/build/libs/*.jar app.jar
+COPY app/build/libs/*.jar app.jar
 
-# Expose port (default Spring Boot port)
 EXPOSE 8080
 
-# Run the application
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,29 @@
+# Build stage
+FROM gradle:8.5-jdk21 AS builder
+
+WORKDIR /build
+
+# Copy gradle files
+COPY build.gradle settings.gradle gradlew ./
+COPY gradle ./gradle
+
+# Copy all modules (including common)
+COPY common ./common
+COPY app ./app
+
+# Build the application (common will be built as dependency)
+RUN ./gradlew :app:bootJar --no-daemon
+
+# Runtime stage
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+
+# Copy the built jar from builder
+COPY --from=builder /build/app/build/libs/*.jar app.jar
+
+# Expose port (default Spring Boot port)
+EXPOSE 8080
+
+# Run the application
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/app/src/main/java/com/example/bssm_dev/domain/docs/model/type/DocsModule.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/docs/model/type/DocsModule.java
@@ -1,7 +1,7 @@
 package com.example.bssm_dev.domain.docs.model.type;
 
 public enum DocsModule {
-    HEADLINE_1, HEADLINE_2, DOCS_1, LIST, CODE, IMAGE;
+    HEADLINE_1, HEADLINE_2, DOCS_1, LIST, CODE, IMAGE, API;
 
     public static DocsModule fromString(String module) {
         return DocsModule.valueOf(module.toUpperCase());

--- a/proxy-service/Dockerfile
+++ b/proxy-service/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM gradle:8.5-jdk21 AS builder
+FROM --platform=linux/amd64 gradle:8.5-jdk21 AS builder
 
 WORKDIR /build
 
@@ -15,7 +15,7 @@ COPY proxy-service ./proxy-service
 RUN ./gradlew :proxy-service:bootJar --no-daemon
 
 # Runtime stage
-FROM eclipse-temurin:21-jre
+FROM --platform=linux/amd64 eclipse-temurin:21-jre
 
 WORKDIR /app
 

--- a/proxy-service/Dockerfile
+++ b/proxy-service/Dockerfile
@@ -1,0 +1,29 @@
+# Build stage
+FROM gradle:8.5-jdk21 AS builder
+
+WORKDIR /build
+
+# Copy gradle files
+COPY build.gradle settings.gradle gradlew ./
+COPY gradle ./gradle
+
+# Copy all modules (including common)
+COPY common ./common
+COPY proxy-service ./proxy-service
+
+# Build the application (common will be built as dependency)
+RUN ./gradlew :proxy-service:bootJar --no-daemon
+
+# Runtime stage
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+
+# Copy the built jar from builder
+COPY --from=builder /build/proxy-service/build/libs/*.jar proxy-service.jar
+
+# Expose port
+EXPOSE 8081
+
+# Run the application
+ENTRYPOINT ["java", "-jar", "proxy-service.jar"]

--- a/proxy-service/Dockerfile
+++ b/proxy-service/Dockerfile
@@ -1,29 +1,9 @@
-# Build stage
-FROM --platform=linux/amd64 gradle:8.5-jdk21 AS builder
-
-WORKDIR /build
-
-# Copy gradle files
-COPY build.gradle settings.gradle gradlew ./
-COPY gradle ./gradle
-
-# Copy all modules (including common)
-COPY common ./common
-COPY proxy-service ./proxy-servic
-
-# Build the application (common will be built as dependency)
-RUN ./gradlew :proxy-service:bootJar --no-daemon
-
-# Runtime stage
 FROM --platform=linux/amd64 eclipse-temurin:21-jre
 
 WORKDIR /app
 
-# Copy the built jar from builder
-COPY --from=builder /build/proxy-service/build/libs/*.jar proxy-service.jar
+COPY proxy-service/build/libs/*.jar proxy-service.jar
 
-# Expose port
 EXPOSE 8081
 
-# Run the application
 ENTRYPOINT ["java", "-jar", "proxy-service.jar"]

--- a/proxy-service/Dockerfile
+++ b/proxy-service/Dockerfile
@@ -9,7 +9,7 @@ COPY gradle ./gradle
 
 # Copy all modules (including common)
 COPY common ./common
-COPY proxy-service ./proxy-service
+COPY proxy-service ./proxy-servic
 
 # Build the application (common will be built as dependency)
 RUN ./gradlew :proxy-service:bootJar --no-daemon

--- a/proxy-service/build.gradle
+++ b/proxy-service/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'io.asyncer:r2dbc-mysql:1.0.5'
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+    implementation "org.apache.commons:commons-pool2"
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.apache.logging.log4j:log4j-to-slf4j'
 

--- a/proxy-service/build.gradle
+++ b/proxy-service/build.gradle
@@ -2,6 +2,12 @@ group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 description = 'bssm_dev_proxy_service'
 
+
+
+springBoot {
+    mainClass = "com.example.bssm_dev.proxy.ProxyServiceApplication"
+}
+
 configurations {
     compileOnly {
         extendsFrom annotationProcessor

--- a/proxy-service/src/main/java/com/example/bssm_dev/domain/api/service/MockRateLimiterService.java
+++ b/proxy-service/src/main/java/com/example/bssm_dev/domain/api/service/MockRateLimiterService.java
@@ -11,7 +11,7 @@ import reactor.core.publisher.Mono;
  */
 @Slf4j
 @Service
-@Profile("dev")
+@Profile("!prod")
 public class MockRateLimiterService implements ApiRateLimiterService {
     
     @Override

--- a/proxy-service/src/main/java/com/example/bssm_dev/domain/api/service/RedisApiRateLimiterService.java
+++ b/proxy-service/src/main/java/com/example/bssm_dev/domain/api/service/RedisApiRateLimiterService.java
@@ -16,7 +16,7 @@ import java.time.format.DateTimeFormatter;
  * Redis String + INCR + TTL 방식으로 분 단위 요청 제한 추적
  */
 @Service
-@Profile("!dev")
+@Profile("prod")
 @RequiredArgsConstructor
 public class RedisApiRateLimiterService implements ApiRateLimiterService {
     private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;

--- a/proxy-service/src/main/java/com/example/bssm_dev/domain/api/service/query/ApiTokenReactiveQueryService.java
+++ b/proxy-service/src/main/java/com/example/bssm_dev/domain/api/service/query/ApiTokenReactiveQueryService.java
@@ -3,6 +3,8 @@ package com.example.bssm_dev.domain.api.service.query;
 import com.example.bssm_dev.domain.api.exception.ApiTokenNotFoundException;
 import com.example.bssm_dev.domain.api.model.r2dbc.ApiTokenR2dbc;
 import com.example.bssm_dev.domain.api.repository.r2dbc.ApiTokenR2dbcRepository;
+import com.example.bssm_dev.proxy.cache.CacheKeys;
+import com.example.bssm_dev.proxy.cache.ReactiveCacheService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
@@ -11,9 +13,14 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class ApiTokenReactiveQueryService {
     private final ApiTokenR2dbcRepository apiTokenR2dbcRepository;
+    private final ReactiveCacheService cacheService;
 
     public Mono<ApiTokenR2dbc> findByTokenClientId(String clientId) {
-        return apiTokenR2dbcRepository.findByClientId(clientId)
-                .switchIfEmpty(Mono.error(ApiTokenNotFoundException::raise));
+        String cacheKey = CacheKeys.apiToken(clientId);
+        return cacheService.getCacheOrFetch(
+                cacheKey,
+                () -> apiTokenR2dbcRepository.findByClientId(clientId),
+                ApiTokenR2dbc.class
+        ).switchIfEmpty(Mono.error(ApiTokenNotFoundException::raise));
     }
 }

--- a/proxy-service/src/main/java/com/example/bssm_dev/domain/api/service/query/ApiUsageReactiveQueryService.java
+++ b/proxy-service/src/main/java/com/example/bssm_dev/domain/api/service/query/ApiUsageReactiveQueryService.java
@@ -5,6 +5,8 @@ import com.example.bssm_dev.domain.api.model.r2dbc.ApiTokenR2dbc;
 import com.example.bssm_dev.domain.api.model.r2dbc.ApiUsageR2dbc;
 import com.example.bssm_dev.domain.api.model.vo.RequestInfo;
 import com.example.bssm_dev.domain.api.repository.r2dbc.ApiUsageR2dbcRepository;
+import com.example.bssm_dev.proxy.cache.CacheKeys;
+import com.example.bssm_dev.proxy.cache.ReactiveCacheService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
@@ -13,10 +15,15 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class ApiUsageReactiveQueryService {
     private final ApiUsageR2dbcRepository apiUsageR2dbcRepository;
+    private final ReactiveCacheService cacheService;
 
     public Mono<ApiUsageR2dbc> findByTokenAndEndpoint(ApiTokenR2dbc apiToken, RequestInfo requestInfo) {
         String endpoint = requestInfo.endpoint();
-        return apiUsageR2dbcRepository.findByApiTokenIdAndEndpoint(apiToken.getApiTokenId(), endpoint)
-                .switchIfEmpty(Mono.error(ApiUsageNotFoundException::raise));
+        String cacheKey = CacheKeys.apiUsage(apiToken.getApiTokenId(), endpoint);
+        return cacheService.getCacheOrFetch(
+                cacheKey,
+                () -> apiUsageR2dbcRepository.findByApiTokenIdAndEndpoint(apiToken.getApiTokenId(), endpoint),
+                ApiUsageR2dbc.class
+        ).switchIfEmpty(Mono.error(ApiUsageNotFoundException::raise));
     }
 }

--- a/proxy-service/src/main/java/com/example/bssm_dev/domain/api/service/query/TokenDomainReactiveQueryService.java
+++ b/proxy-service/src/main/java/com/example/bssm_dev/domain/api/service/query/TokenDomainReactiveQueryService.java
@@ -2,18 +2,24 @@ package com.example.bssm_dev.domain.api.service.query;
 
 import com.example.bssm_dev.domain.api.model.r2dbc.TokenDomainR2dbc;
 import com.example.bssm_dev.domain.api.repository.r2dbc.TokenDomainR2dbcRepository;
+import com.example.bssm_dev.proxy.cache.CacheKeys;
+import com.example.bssm_dev.proxy.cache.ReactiveCacheService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class TokenDomainReactiveQueryService {
     private final TokenDomainR2dbcRepository tokenDomainR2dbcRepository;
+    private final ReactiveCacheService cacheService;
 
     public Flux<TokenDomainR2dbc> findByApiTokenId(Long apiTokenId) {
-        return tokenDomainR2dbcRepository.findByApiTokenId(apiTokenId);
+        String cacheKey = CacheKeys.tokenDomain(apiTokenId);
+        return cacheService.getCacheOrFetchList(
+                cacheKey,
+                () -> tokenDomainR2dbcRepository.findByApiTokenId(apiTokenId),
+                TokenDomainR2dbc.class
+        );
     }
 }

--- a/proxy-service/src/main/java/com/example/bssm_dev/proxy/cache/CacheKeys.java
+++ b/proxy-service/src/main/java/com/example/bssm_dev/proxy/cache/CacheKeys.java
@@ -1,0 +1,23 @@
+package com.example.bssm_dev.proxy.cache;
+
+public final class CacheKeys {
+    private CacheKeys() {}
+
+    private static final String PREFIX = "proxy:";
+
+    public static final String API_TOKEN_PREFIX = PREFIX + "api_token:";
+    public static final String TOKEN_DOMAIN_PREFIX = PREFIX + "token_domain:";
+    public static final String API_USAGE_PREFIX = PREFIX + "api_usage:";
+
+    public static String apiToken(String clientId) {
+        return API_TOKEN_PREFIX + clientId;
+    }
+
+    public static String tokenDomain(Long apiTokenId) {
+        return TOKEN_DOMAIN_PREFIX + apiTokenId;
+    }
+
+    public static String apiUsage(Long apiTokenId, String endpoint) {
+        return API_USAGE_PREFIX + apiTokenId + ":" + endpoint;
+    }
+}

--- a/proxy-service/src/main/java/com/example/bssm_dev/proxy/cache/CacheProperties.java
+++ b/proxy-service/src/main/java/com/example/bssm_dev/proxy/cache/CacheProperties.java
@@ -1,0 +1,12 @@
+package com.example.bssm_dev.proxy.cache;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+@Data
+@ConfigurationProperties(prefix = "proxy.cache")
+public class CacheProperties {
+    private Duration ttl = Duration.ofMinutes(5);
+}

--- a/proxy-service/src/main/java/com/example/bssm_dev/proxy/cache/ReactiveCacheService.java
+++ b/proxy-service/src/main/java/com/example/bssm_dev/proxy/cache/ReactiveCacheService.java
@@ -1,0 +1,114 @@
+package com.example.bssm_dev.proxy.cache;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Supplier;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@EnableConfigurationProperties(CacheProperties.class)
+public class ReactiveCacheService {
+    private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
+    private final ObjectMapper objectMapper;
+    private final CacheProperties cacheProperties;
+
+    public <T> Mono<T> getCacheOrFetch(String cacheKey, Supplier<Mono<T>> dbFetcher, Class<T> type) {
+        return getCacheOrFetch(cacheKey, dbFetcher, type, cacheProperties.getTtl());
+    }
+
+    public <T> Mono<T> getCacheOrFetch(String cacheKey, Supplier<Mono<T>> dbFetcher, Class<T> type, Duration ttl) {
+        return reactiveRedisTemplate.opsForValue().get(cacheKey)
+                .flatMap(cached -> {
+                    try {
+                        T value = objectMapper.readValue(cached, type);
+                        log.debug("Cache hit for key: {}", cacheKey);
+                        return Mono.just(value);
+                    } catch (Exception e) {
+                        log.warn("Failed to deserialize cache for key: {}", cacheKey, e);
+                        return Mono.empty();
+                    }
+                })
+                .switchIfEmpty(
+                        dbFetcher.get()
+                                .flatMap(value -> {
+                                    try {
+                                        String json = objectMapper.writeValueAsString(value);
+                                        return reactiveRedisTemplate.opsForValue()
+                                                .set(cacheKey, json, ttl)
+                                                .doOnSuccess(v -> log.debug("Cache set for key: {}", cacheKey))
+                                                .thenReturn(value);
+                                    } catch (Exception e) {
+                                        log.warn("Failed to serialize value for cache key: {}", cacheKey, e);
+                                        return Mono.just(value);
+                                    }
+                                })
+                );
+    }
+
+    public <T> Flux<T> getCacheOrFetchList(String cacheKey, Supplier<Flux<T>> dbFetcher, Class<T> elementType) {
+        return getCacheOrFetchList(cacheKey, dbFetcher, elementType, cacheProperties.getTtl());
+    }
+
+    public <T> Flux<T> getCacheOrFetchList(String cacheKey, Supplier<Flux<T>> dbFetcher, Class<T> elementType, Duration ttl) {
+        return reactiveRedisTemplate.opsForValue().get(cacheKey)
+                .flatMapMany(cached -> {
+                    try {
+                        List<T> values = objectMapper.readValue(cached, 
+                                objectMapper.getTypeFactory().constructCollectionType(List.class, elementType));
+                        log.debug("Cache hit for list key: {}", cacheKey);
+                        return Flux.fromIterable(values);
+                    } catch (Exception e) {
+                        log.warn("Failed to deserialize cache for list key: {}", cacheKey, e);
+                        return Flux.empty();
+                    }
+                })
+                .switchIfEmpty(
+                        dbFetcher.get()
+                                .collectList()
+                                .flatMapMany(values -> {
+                                    try {
+                                        String json = objectMapper.writeValueAsString(values);
+                                        return reactiveRedisTemplate.opsForValue()
+                                                .set(cacheKey, json, ttl)
+                                                .doOnSuccess(v -> log.debug("Cache set for list key: {}", cacheKey))
+                                                .thenMany(Flux.fromIterable(values));
+                                    } catch (Exception e) {
+                                        log.warn("Failed to serialize list for cache key: {}", cacheKey, e);
+                                        return Flux.fromIterable(values);
+                                    }
+                                })
+                );
+    }
+
+    public Mono<Boolean> evict(String cacheKey) {
+        return reactiveRedisTemplate.delete(cacheKey)
+                .map(count -> count > 0)
+                .doOnSuccess(deleted -> {
+                    if (deleted) {
+                        log.debug("Cache evicted for key: {}", cacheKey);
+                    }
+                });
+    }
+
+    public Mono<Long> evictByPattern(String pattern) {
+        return reactiveRedisTemplate.keys(pattern)
+                .collectList()
+                .flatMap(keys -> {
+                    if (keys.isEmpty()) {
+                        return Mono.just(0L);
+                    }
+                    return reactiveRedisTemplate.delete(keys.toArray(new String[0]))
+                            .doOnSuccess(count -> log.debug("Evicted {} keys matching pattern: {}", count, pattern));
+                });
+    }
+}

--- a/proxy-service/src/main/java/com/example/bssm_dev/proxy/config/RedisConfig.java
+++ b/proxy-service/src/main/java/com/example/bssm_dev/proxy/config/RedisConfig.java
@@ -5,7 +5,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Configuration
 public class RedisConfig {
@@ -20,6 +23,25 @@ public class RedisConfig {
                 .value(serializer)
                 .hashKey(serializer)
                 .hashValue(serializer)
+                .build();
+        
+        return new ReactiveRedisTemplate<>(connectionFactory, serializationContext);
+    }
+
+    @Bean
+    public ReactiveRedisTemplate<String, Object> reactiveRedisObjectTemplate(
+            ReactiveRedisConnectionFactory connectionFactory,
+            ObjectMapper objectMapper) {
+        StringRedisSerializer keySerializer = new StringRedisSerializer();
+        Jackson2JsonRedisSerializer<Object> valueSerializer = 
+                new Jackson2JsonRedisSerializer<>(objectMapper, Object.class);
+        
+        RedisSerializationContext<String, Object> serializationContext = RedisSerializationContext
+                .<String, Object>newSerializationContext()
+                .key(keySerializer)
+                .value(valueSerializer)
+                .hashKey(keySerializer)
+                .hashValue(valueSerializer)
                 .build();
         
         return new ReactiveRedisTemplate<>(connectionFactory, serializationContext);

--- a/proxy-service/src/main/java/com/example/bssm_dev/proxy/queue/HrnRequestQueue.java
+++ b/proxy-service/src/main/java/com/example/bssm_dev/proxy/queue/HrnRequestQueue.java
@@ -5,29 +5,37 @@ import reactor.core.Disposable;
 import reactor.core.publisher.MonoSink;
 
 import java.time.Duration;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.time.Instant;
+import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class SemaphoreRequestQueue implements RequestQueue {
+/**
+ * HRN(Highest Response Ratio Next) 기반 Request Queue 구현.
+ * 사용자의 실패 횟수에 따른 priority와 대기 시간을 고려하여 스케줄링합니다.
+ * 
+ * Response Ratio = (대기시간 + 서비스시간) / 서비스시간
+ * 여기서는 간단히: effectivePriority = basePriority + (waitTimeSeconds * 0.1)
+ */
+public class HrnRequestQueue implements RequestQueue {
     private final Semaphore semaphore;
     private final Duration timeout;
-    private final ConcurrentLinkedQueue<Waiter> waiters = new ConcurrentLinkedQueue<>();
+    private final PriorityBlockingQueue<Waiter> waiters;
 
-    public SemaphoreRequestQueue(int maxInflight, Duration timeout) {
+    public HrnRequestQueue(int maxInflight, Duration timeout) {
         this.semaphore = new Semaphore(maxInflight);
         this.timeout = timeout;
+        this.waiters = new PriorityBlockingQueue<>();
     }
 
     @Override
     public Mono<Boolean> tryAcquire(String clientId, double priority) {
-        // FIFO 방식: clientId와 priority는 무시됨
         return Mono.defer(() -> {
             if (semaphore.tryAcquire()) {
                 return Mono.just(true);
             }
             return Mono.<Boolean>create(sink -> {
-                Waiter waiter = new Waiter(sink);
+                Waiter waiter = new Waiter(sink, clientId, priority);
                 waiters.offer(waiter);
 
                 Disposable timeoutTask = Mono.delay(timeout)
@@ -63,13 +71,19 @@ public class SemaphoreRequestQueue implements RequestQueue {
         });
     }
 
-    private static final class Waiter {
+    private static final class Waiter implements Comparable<Waiter> {
         private final AtomicBoolean completed = new AtomicBoolean(false);
         private final MonoSink<Boolean> sink;
+        private final String clientId;
+        private final double basePriority;
+        private final Instant enqueueTime;
         private Disposable timeoutTask;
 
-        private Waiter(MonoSink<Boolean> sink) {
+        private Waiter(MonoSink<Boolean> sink, String clientId, double basePriority) {
             this.sink = sink;
+            this.clientId = clientId;
+            this.basePriority = basePriority;
+            this.enqueueTime = Instant.now();
         }
 
         private void setTimeoutTask(Disposable timeoutTask) {
@@ -85,6 +99,23 @@ public class SemaphoreRequestQueue implements RequestQueue {
             }
             sink.success(value);
             return true;
+        }
+
+        /**
+         * HRN 알고리즘에 따른 effective priority 계산.
+         * 높은 priority와 오래 기다린 요청이 먼저 처리됩니다.
+         */
+        private double getEffectivePriority() {
+            long waitTimeMillis = Duration.between(enqueueTime, Instant.now()).toMillis();
+            double waitTimeSeconds = waitTimeMillis / 1000.0;
+            // HRN: 대기시간이 길수록 priority 증가 (aging 효과)
+            return basePriority + (waitTimeSeconds * 0.1);
+        }
+
+        @Override
+        public int compareTo(Waiter other) {
+            // 높은 effective priority가 먼저 (내림차순)
+            return Double.compare(other.getEffectivePriority(), this.getEffectivePriority());
         }
     }
 }

--- a/proxy-service/src/main/java/com/example/bssm_dev/proxy/queue/ProxyQueueConfig.java
+++ b/proxy-service/src/main/java/com/example/bssm_dev/proxy/queue/ProxyQueueConfig.java
@@ -10,7 +10,7 @@ public class ProxyQueueConfig {
 
     @Bean
     public RequestQueue requestQueue(ProxyQueueProperties properties) {
-        return new SemaphoreRequestQueue(
+        return new HrnRequestQueue(
                 properties.getMaxInflight(),
                 properties.getAcquireTimeout()
         );

--- a/proxy-service/src/main/java/com/example/bssm_dev/proxy/queue/ProxyQueueProperties.java
+++ b/proxy-service/src/main/java/com/example/bssm_dev/proxy/queue/ProxyQueueProperties.java
@@ -10,4 +10,9 @@ import java.time.Duration;
 public class ProxyQueueProperties {
     private int maxInflight = 80;
     private Duration acquireTimeout = Duration.ofSeconds(1);
+
+    // HRN Priority settings
+    private double basePriority = 1.0;
+    private double priorityIncrement = 0.2;
+    private double maxPriority = 3.0;
 }

--- a/proxy-service/src/main/java/com/example/bssm_dev/proxy/queue/ProxyRequestQueueFilter.java
+++ b/proxy-service/src/main/java/com/example/bssm_dev/proxy/queue/ProxyRequestQueueFilter.java
@@ -16,8 +16,11 @@ import com.example.bssm_dev.proxy.error.TooManyRequestsException;
 public class ProxyRequestQueueFilter implements WebFilter {
     private static final String PROXY_BROWSER = "/proxy-browser";
     private static final String PROXY_SERVER = "/proxy-server";
+    private static final String TOKEN_HEADER = "bssm-dev-token";
 
     private final RequestQueue requestQueue;
+    private final UserPriorityService userPriorityService;
+
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
         String path = exchange.getRequest().getPath().value();
@@ -25,17 +28,21 @@ public class ProxyRequestQueueFilter implements WebFilter {
             return chain.filter(exchange);
         }
 
-        return Mono.usingWhen(
-                requestQueue.tryAcquire(),
-                acquired -> {
-                    if (!acquired) {
-                        return Mono.error(new TooManyRequestsException());
-                    }
-                    return chain.filter(exchange);
-                },
-                acquired -> acquired ? requestQueue.release() : Mono.empty(),
-                (acquired, err) -> acquired ? requestQueue.release() : Mono.empty(),
-                acquired -> acquired ? requestQueue.release() : Mono.empty()
-        );
+        String clientId = exchange.getRequest().getHeaders().getFirst(TOKEN_HEADER);
+
+        return userPriorityService.getPriority(clientId)
+                .flatMap(priority -> Mono.usingWhen(
+                        requestQueue.tryAcquire(clientId, priority),
+                        acquired -> {
+                            if (!acquired) {
+                                return userPriorityService.incrementFailure(clientId)
+                                        .then(Mono.error(new TooManyRequestsException()));
+                            }
+                            return chain.filter(exchange);
+                        },
+                        acquired -> acquired ? requestQueue.release() : Mono.empty(),
+                        (acquired, err) -> acquired ? requestQueue.release() : Mono.empty(),
+                        acquired -> acquired ? requestQueue.release() : Mono.empty()
+                ));
     }
 }

--- a/proxy-service/src/main/java/com/example/bssm_dev/proxy/queue/RequestQueue.java
+++ b/proxy-service/src/main/java/com/example/bssm_dev/proxy/queue/RequestQueue.java
@@ -3,6 +3,6 @@ package com.example.bssm_dev.proxy.queue;
 import reactor.core.publisher.Mono;
 
 public interface RequestQueue {
-    Mono<Boolean> tryAcquire();
+    Mono<Boolean> tryAcquire(String clientId, double priority);
     Mono<Void> release();
 }

--- a/proxy-service/src/main/java/com/example/bssm_dev/proxy/queue/UserPriorityService.java
+++ b/proxy-service/src/main/java/com/example/bssm_dev/proxy/queue/UserPriorityService.java
@@ -1,0 +1,60 @@
+package com.example.bssm_dev.proxy.queue;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserPriorityService {
+    private static final String FAILURE_COUNT_PREFIX = "proxy:queue:failure:";
+    private static final Duration FAILURE_COUNT_TTL = Duration.ofHours(1);
+
+    private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
+    private final ProxyQueueProperties properties;
+
+    public Mono<Double> getPriority(String clientId) {
+        if (clientId == null || clientId.isBlank()) {
+            return Mono.just(properties.getBasePriority());
+        }
+
+        String key = FAILURE_COUNT_PREFIX + clientId;
+        return reactiveRedisTemplate.opsForValue().get(key)
+                .map(Integer::parseInt)
+                .defaultIfEmpty(0)
+                .map(this::calculatePriority);
+    }
+
+    public Mono<Void> incrementFailure(String clientId) {
+        if (clientId == null || clientId.isBlank()) {
+            return Mono.empty();
+        }
+
+        String key = FAILURE_COUNT_PREFIX + clientId;
+        return reactiveRedisTemplate.opsForValue().increment(key)
+                .flatMap(count -> reactiveRedisTemplate.expire(key, FAILURE_COUNT_TTL))
+                .doOnSuccess(v -> log.debug("Incremented failure count for client: {}", clientId))
+                .then();
+    }
+
+    public Mono<Void> resetFailure(String clientId) {
+        if (clientId == null || clientId.isBlank()) {
+            return Mono.empty();
+        }
+
+        String key = FAILURE_COUNT_PREFIX + clientId;
+        return reactiveRedisTemplate.delete(key)
+                .doOnSuccess(v -> log.debug("Reset failure count for client: {}", clientId))
+                .then();
+    }
+
+    private double calculatePriority(int failureCount) {
+        double priority = properties.getBasePriority() + (failureCount * properties.getPriorityIncrement());
+        return Math.min(priority, properties.getMaxPriority());
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,10 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'bssm_dev'
 
 include 'app'


### PR DESCRIPTION
## RDB 캐싱
- Proxy 수행 시 RDB 캐싱

## Proxy Inflight Queue 스케쥴링 알고리즘 변경
- 기존 FIFO 구조에서 사용자별 HRN 도입
- 요청 타임아웃 실패 수에 따른 우선순위 증가
- CPU 처리량 한계로 인한 시끄러운 이웃 문제 보완을 위함