### PR TITLE
보안 요소 추가

### DIFF
--- a/app/src/main/java/com/example/bssm_dev/domain/api/controller/query/ApiTokenQueryController.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/controller/query/ApiTokenQueryController.java
@@ -50,4 +50,16 @@ public class ApiTokenQueryController {
         ResponseDto<ApiTokenResponse> responseDto = HttpUtil.success("Successfully retrieved API token detail", response);
         return ResponseEntity.ok(responseDto);
     }
+
+    /**
+     * client-id로 API Token 조회 (인증 불필요)
+     */
+    @GetMapping("/client/{clientId}")
+    public ResponseEntity<ResponseDto<ApiTokenResponse>> getApiTokenDetailByClientId(
+            @PathVariable String clientId
+    ) {
+        ApiTokenResponse response = apiTokenQueryService.getApiTokenDetailByClientId(clientId);
+        ResponseDto<ApiTokenResponse> responseDto = HttpUtil.success("Successfully retrieved API token detail", response);
+        return ResponseEntity.ok(responseDto);
+    }
 }

--- a/app/src/main/java/com/example/bssm_dev/domain/api/service/command/ApiCommandService.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/service/command/ApiCommandService.java
@@ -1,5 +1,6 @@
 package com.example.bssm_dev.domain.api.service.command;
 
+import com.example.bssm_dev.common.util.DomainValidator;
 import com.example.bssm_dev.domain.api.model.Api;
 import com.example.bssm_dev.domain.api.repository.ApiRepository;
 import com.example.bssm_dev.domain.docs.model.ContentDocsPage;
@@ -33,6 +34,9 @@ public class ApiCommandService {
             Boolean autoApproval
     ) {
         log.info("Creating APIs for docsId: {}", docsId);
+
+        // SSRF 방어: API 등록 시점에 domain 검증 (Layer 1)
+        DomainValidator.validate(domain);
 
         List<Api> apis = new ArrayList<>();
         extractApisFromSidebar(sideBar.getSideBarBlocks(), docsPages, creator, domain, repositoryUrl, autoApproval, apis);

--- a/app/src/main/java/com/example/bssm_dev/domain/api/service/query/ApiTokenQueryService.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/service/query/ApiTokenQueryService.java
@@ -58,7 +58,14 @@ public class ApiTokenQueryService {
         // 사용자 권한 확인
         boolean equalsUser = apiToken.isOwner(user);
         if (!equalsUser) throw UnauthorizedApiTokenAccessException.raise();
-        
+
+        return apiTokenMapper.toApiTokenResponse(apiToken);
+    }
+
+    public ApiTokenResponse getApiTokenDetailByClientId(String clientId) {
+        ApiToken apiToken = apiTokenRepository.findByTokenUUID(clientId)
+                .orElseThrow(ApiTokenNotFoundException::raise);
+
         return apiTokenMapper.toApiTokenResponse(apiToken);
     }
 }

--- a/app/src/main/java/com/example/bssm_dev/global/config/SecurityConfig.java
+++ b/app/src/main/java/com/example/bssm_dev/global/config/SecurityConfig.java
@@ -95,6 +95,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/proxy-server/**").permitAll()
                         .requestMatchers("/api/proxy-browser/**").permitAll()
                         .requestMatchers("/api/healthy/**").permitAll()
+                        .requestMatchers("/api/token/client/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);

--- a/common/src/main/java/com/example/bssm_dev/common/util/DomainValidator.java
+++ b/common/src/main/java/com/example/bssm_dev/common/util/DomainValidator.java
@@ -1,0 +1,210 @@
+package com.example.bssm_dev.common.util;
+
+import com.example.bssm_dev.exception.ErrorCode;
+import com.example.bssm_dev.exception.GlobalException;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+
+/**
+ * SSRF(Server-Side Request Forgery) 방어를 위한 도메인 검증 유틸리티.
+ *
+ * <p>검증 규칙:
+ * <ol>
+ *   <li>scheme은 https:// 만 허용</li>
+ *   <li>숫자 IP 직접 입력 차단 (IPv4 / IPv6)</li>
+ *   <li>내부 hostname 패턴 차단 (localhost, *.local, *.internal 등)</li>
+ *   <li>DNS 해석 후 resolved IP가 내부 대역이면 차단</li>
+ * </ol>
+ */
+public final class DomainValidator {
+
+    private static final Logger log = Logger.getLogger(DomainValidator.class.getName());
+
+    // RFC 1918 / loopback / link-local / CGNAT 패턴
+    private static final List<long[]> BLOCKED_IPV4_RANGES = List.of(
+            range("10.0.0.0", "10.255.255.255"),        // RFC 1918
+            range("172.16.0.0", "172.31.255.255"),       // RFC 1918
+            range("192.168.0.0", "192.168.255.255"),     // RFC 1918
+            range("127.0.0.0", "127.255.255.255"),       // Loopback
+            range("169.254.0.0", "169.254.255.255"),     // Link-local (AWS metadata 등)
+            range("100.64.0.0", "100.127.255.255"),      // CGNAT
+            range("0.0.0.0", "0.255.255.255"),           // 현재 네트워크
+            range("192.0.0.0", "192.0.0.255"),           // IETF Protocol
+            range("198.51.100.0", "198.51.100.255"),     // TEST-NET-2
+            range("203.0.113.0", "203.0.113.255"),       // TEST-NET-3
+            range("240.0.0.0", "255.255.255.255")        // Reserved / Broadcast
+    );
+
+    private static final Pattern IPV4_PATTERN =
+            Pattern.compile("^(\\d{1,3}\\.){3}\\d{1,3}$");
+
+    // IPv6 주소 직접 입력 차단 패턴 (::1, [::1], [2001:db8::1] 등)
+    private static final Pattern IPV6_PATTERN =
+            Pattern.compile("^\\[?[0-9a-fA-F:]+]?$");
+
+    private static final List<Pattern> BLOCKED_HOSTNAME_PATTERNS = List.of(
+            Pattern.compile("^localhost$", Pattern.CASE_INSENSITIVE),
+            Pattern.compile(".*\\.local$", Pattern.CASE_INSENSITIVE),
+            Pattern.compile(".*\\.internal$", Pattern.CASE_INSENSITIVE),
+            Pattern.compile(".*\\.intranet$", Pattern.CASE_INSENSITIVE),
+            Pattern.compile(".*\\.corp$", Pattern.CASE_INSENSITIVE),
+            Pattern.compile(".*\\.lan$", Pattern.CASE_INSENSITIVE)
+    );
+
+    private DomainValidator() {
+    }
+
+    /**
+     * 도메인 URL 검증. 위반 시 GlobalException 을 던집니다.
+     *
+     * @param domainUrl 검증할 URL 문자열 (예: https://api.example.com)
+     */
+    public static void validate(String domainUrl) {
+        if (domainUrl == null || domainUrl.isBlank()) {
+            throw InvalidDomainUrlException.raise();
+        }
+
+        URL url = parseUrl(domainUrl);
+
+        validateScheme(url);
+        String hostname = url.getHost();
+        validateHostname(hostname);
+        validateResolvedIp(hostname, domainUrl);
+    }
+
+    private static URL parseUrl(String domainUrl) {
+        try {
+            return new URI(domainUrl).toURL();
+        } catch (URISyntaxException | IllegalArgumentException | java.net.MalformedURLException e) {
+            log.warning("[DomainValidator] URL 파싱 실패: " + domainUrl);
+            throw InvalidDomainUrlException.raise();
+        }
+    }
+
+    private static void validateScheme(URL url) {
+        if (!"https".equalsIgnoreCase(url.getProtocol())) {
+            log.warning("[DomainValidator] https가 아닌 scheme 차단: scheme=" + url.getProtocol());
+            throw InvalidDomainUrlException.raise();
+        }
+    }
+
+    private static void validateHostname(String hostname) {
+        if (hostname == null || hostname.isBlank()) {
+            throw InvalidDomainUrlException.raise();
+        }
+
+        // IPv4 직접 입력 차단
+        if (IPV4_PATTERN.matcher(hostname).matches()) {
+            log.warning("[DomainValidator] IPv4 직접 입력 차단: " + hostname);
+            throw BlockedInternalDomainException.raise();
+        }
+
+        // IPv6 직접 입력 차단
+        if (IPV6_PATTERN.matcher(hostname).matches()) {
+            log.warning("[DomainValidator] IPv6 직접 입력 차단: " + hostname);
+            throw BlockedInternalDomainException.raise();
+        }
+
+        // 내부 hostname 패턴 차단
+        for (Pattern pattern : BLOCKED_HOSTNAME_PATTERNS) {
+            if (pattern.matcher(hostname).matches()) {
+                log.warning("[DomainValidator] 내부 hostname 패턴 차단: " + hostname);
+                throw BlockedInternalDomainException.raise();
+            }
+        }
+    }
+
+    private static void validateResolvedIp(String hostname, String domainUrl) {
+        try {
+            InetAddress[] addresses = InetAddress.getAllByName(hostname);
+            for (InetAddress address : addresses) {
+                byte[] raw = address.getAddress();
+
+                // IPv6 loopback (::1) 및 링크로컬 (fe80::/10) 차단
+                if (raw.length == 16) {
+                    if (isBlockedIpv6(raw)) {
+                        log.warning("[DomainValidator] 내부 IPv6 resolved 차단: hostname=" + hostname + ", ip=" + address.getHostAddress());
+                        throw BlockedInternalDomainException.raise();
+                    }
+                    continue;
+                }
+
+                // IPv4 내부 대역 차단
+                long ip = ipToLong(raw);
+                for (long[] range : BLOCKED_IPV4_RANGES) {
+                    if (ip >= range[0] && ip <= range[1]) {
+                        log.warning("[DomainValidator] 내부 IPv4 resolved 차단: hostname=" + hostname + ", ip=" + address.getHostAddress());
+                        throw BlockedInternalDomainException.raise();
+                    }
+                }
+            }
+        } catch (UnknownHostException e) {
+            // DNS 해석 실패 = 존재하지 않는 도메인 → 차단
+            log.warning("[DomainValidator] DNS 해석 실패 차단: hostname=" + hostname);
+            throw InvalidDomainUrlException.raise();
+        }
+    }
+
+    private static boolean isBlockedIpv6(byte[] raw) {
+        // ::1 loopback
+        boolean isLoopback = true;
+        for (int i = 0; i < 15; i++) {
+            if (raw[i] != 0) { isLoopback = false; break; }
+        }
+        if (isLoopback && raw[15] == 1) return true;
+
+        // fe80::/10 link-local
+        if ((raw[0] & 0xFF) == 0xFE && (raw[1] & 0xC0) == 0x80) return true;
+
+        // fc00::/7 unique local
+        if ((raw[0] & 0xFE) == 0xFC) return true;
+
+        return false;
+    }
+
+    private static long ipToLong(byte[] raw) {
+        return ((raw[0] & 0xFFL) << 24)
+                | ((raw[1] & 0xFFL) << 16)
+                | ((raw[2] & 0xFFL) << 8)
+                | (raw[3] & 0xFFL);
+    }
+
+    private static long[] range(String start, String end) {
+        try {
+            long s = ipToLong(InetAddress.getByName(start).getAddress());
+            long e = ipToLong(InetAddress.getByName(end).getAddress());
+            return new long[]{s, e};
+        } catch (UnknownHostException ex) {
+            throw new IllegalStateException("IP 범위 초기화 실패: " + start + " - " + end, ex);
+        }
+    }
+
+    // --- 예외 클래스 ---
+
+    public static class InvalidDomainUrlException extends GlobalException {
+        private InvalidDomainUrlException() {
+            super(ErrorCode.INVALID_DOMAIN_URL);
+        }
+
+        public static InvalidDomainUrlException raise() {
+            return new InvalidDomainUrlException();
+        }
+    }
+
+    public static class BlockedInternalDomainException extends GlobalException {
+        private BlockedInternalDomainException() {
+            super(ErrorCode.BLOCKED_INTERNAL_DOMAIN);
+        }
+
+        public static BlockedInternalDomainException raise() {
+            return new BlockedInternalDomainException();
+        }
+    }
+}

--- a/common/src/main/java/com/example/bssm_dev/exception/ErrorCode.java
+++ b/common/src/main/java/com/example/bssm_dev/exception/ErrorCode.java
@@ -56,7 +56,10 @@ public enum ErrorCode {
     UNAUTHORIZED_ACCESS(403, "권한이 없습니다."),
     DOCS_REFERENCE_PAGE_NOT_EDITABLE(400, "참조 페이지는 직접 수정할 수 없습니다."),
     DOCS_CUSTOM_API_PAGE_MUST_BE_REFERENCE(400, "커스텀 문서의 API 페이지는 참조 페이지여야 합니다."),
-    DOCS_TITLE_ALREADY_EXISTS(400, "이미 사용 중인 문서 제목입니다.");
+    DOCS_TITLE_ALREADY_EXISTS(400, "이미 사용 중인 문서 제목입니다."),
+    INVALID_DOMAIN_URL(400, "유효하지 않은 도메인 URL입니다. https:// 로 시작하는 공개 도메인만 허용됩니다."),
+    BLOCKED_INTERNAL_DOMAIN(400, "내부 네트워크 주소로의 요청은 허용되지 않습니다."),
+    BLOCKED_CONTENT_TYPE(502, "허용되지 않는 Content-Type의 응답입니다.");
 
 
     private final int statusCode;

--- a/proxy-service/src/main/java/com/example/bssm_dev/domain/api/executor/ApiRequestExecutor.java
+++ b/proxy-service/src/main/java/com/example/bssm_dev/domain/api/executor/ApiRequestExecutor.java
@@ -1,5 +1,6 @@
 package com.example.bssm_dev.domain.api.executor;
 
+import com.example.bssm_dev.common.util.DomainValidator;
 import com.example.bssm_dev.domain.api.model.r2dbc.ApiUsageR2dbc;
 import com.example.bssm_dev.domain.api.model.type.MethodType;
 import com.example.bssm_dev.domain.api.model.vo.RequestInfo;
@@ -33,6 +34,10 @@ public class ApiRequestExecutor {
     }
 
     private static Mono<ResponseEntity<byte[]>> request(String endpoint, String apiDomain, MethodType methodType, Object body, java.util.Map<String, String> headers) {
+        // SSRF 방어: 프록시 실행 직전 domain 검증 (이중 방어선)
+        // DB에 저장된 값도 신뢰하지 않고 매 요청마다 검증
+        DomainValidator.validate(apiDomain);
+
         RestRequester requester = RestRequester.of(apiDomain);
         return switch (methodType) {
             case GET -> requester.get(endpoint, headers);

--- a/proxy-service/src/main/java/com/example/bssm_dev/domain/api/log/service/ProxyLogEventPublisher.java
+++ b/proxy-service/src/main/java/com/example/bssm_dev/domain/api/log/service/ProxyLogEventPublisher.java
@@ -220,8 +220,25 @@ public class ProxyLogEventPublisher {
         if (bodyBytes == null) {
             return new TruncatedBody(null, false, 0L);
         }
+        // 바이너리 데이터를 UTF-8로 강제 변환하면 로그가 깨지므로
+        // 유효한 UTF-8 텍스트인지 먼저 확인한다
+        if (!isValidUtf8Text(bodyBytes)) {
+            return new TruncatedBody("[binary data]", false, (long) bodyBytes.length);
+        }
         String asString = new String(bodyBytes, StandardCharsets.UTF_8);
         return truncateBody(asString);
+    }
+
+    private boolean isValidUtf8Text(byte[] bytes) {
+        try {
+            java.nio.charset.CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(java.nio.charset.CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(java.nio.charset.CodingErrorAction.REPORT);
+            decoder.decode(java.nio.ByteBuffer.wrap(bytes));
+            return true;
+        } catch (java.nio.charset.CharacterCodingException e) {
+            return false;
+        }
     }
 
     private TruncatedBody truncateBody(Object body) {

--- a/proxy-service/src/main/java/com/example/bssm_dev/domain/api/requester/impl/RestRequester.java
+++ b/proxy-service/src/main/java/com/example/bssm_dev/domain/api/requester/impl/RestRequester.java
@@ -28,6 +28,9 @@ public class RestRequester implements Requester {
         HttpClient httpClient = HttpClient.create()
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
                 .responseTimeout(Duration.ofSeconds(30))
+                // 리다이렉트 비활성화: 3xx 응답을 자동으로 따라가지 않음
+                // 악성 서버가 내부 주소(예: http://169.254.169.254/)로 리다이렉트하는 SSRF 우회 차단
+                .followRedirect(false)
                 .doOnConnected(conn ->
                         conn.addHandlerLast(new ReadTimeoutHandler(30, TimeUnit.SECONDS))
                                 .addHandlerLast(new WriteTimeoutHandler(30, TimeUnit.SECONDS))

--- a/proxy-service/src/main/java/com/example/bssm_dev/domain/api/requester/util/ResponseEntitySanitizer.java
+++ b/proxy-service/src/main/java/com/example/bssm_dev/domain/api/requester/util/ResponseEntitySanitizer.java
@@ -1,23 +1,73 @@
 package com.example.bssm_dev.domain.api.requester.util;
 
+import com.example.bssm_dev.exception.ErrorCode;
+import com.example.bssm_dev.exception.GlobalException;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
+import java.util.Set;
+
 public final class ResponseEntitySanitizer {
+
+    /**
+     * 허용하는 Content-Type 목록.
+     * 이 외의 타입은 악성 바이너리 또는 스크립트 전달 가능성이 있어 차단한다.
+     */
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
+            "application/json",
+            "application/json; charset=utf-8",
+            "text/plain",
+            "text/plain; charset=utf-8",
+            "text/xml",
+            "application/xml",
+            "application/x-www-form-urlencoded"
+    );
 
     private ResponseEntitySanitizer() {
     }
 
     public static ResponseEntity<byte[]> sanitize(ResponseEntity<byte[]> entity) {
+        validateContentType(entity.getHeaders());
+
         HttpHeaders filtered = new HttpHeaders();
         entity.getHeaders().forEach((name, values) -> {
-            boolean shouldForward = !(
-                    HeaderFilterUtil.isHopByHopHeader(name) || HeaderFilterUtil.isExcludedResponseHeader(name)
-            );
-            if (shouldForward) {
-                filtered.put(name, values);
+            // hop-by-hop 헤더 및 CORS 헤더 제거
+            if (HeaderFilterUtil.isHopByHopHeader(name) || HeaderFilterUtil.isExcludedResponseHeader(name)) {
+                return;
             }
+            // Content-Disposition 제거: 악성 파일 다운로드 유도 방지
+            if ("content-disposition".equalsIgnoreCase(name)) {
+                return;
+            }
+            filtered.put(name, values);
         });
         return new ResponseEntity<>(entity.getBody(), filtered, entity.getStatusCode());
+    }
+
+    private static void validateContentType(HttpHeaders headers) {
+        MediaType contentType = headers.getContentType();
+        if (contentType == null) {
+            return;
+        }
+        // charset 등 파라미터를 제거한 기본 타입으로 비교
+        String baseType = contentType.getType() + "/" + contentType.getSubtype();
+        String baseTypeWithCharset = headers.getFirst(HttpHeaders.CONTENT_TYPE);
+
+        boolean allowed = ALLOWED_CONTENT_TYPES.stream()
+                .anyMatch(allowed_ ->
+                        allowed_.equalsIgnoreCase(baseType)
+                        || (baseTypeWithCharset != null && baseTypeWithCharset.toLowerCase().startsWith(allowed_.toLowerCase()))
+                );
+
+        if (!allowed) {
+            throw new BlockedContentTypeException(contentType.toString());
+        }
+    }
+
+    public static class BlockedContentTypeException extends GlobalException {
+        public BlockedContentTypeException(String contentType) {
+            super(ErrorCode.BLOCKED_CONTENT_TYPE);
+        }
     }
 }

--- a/proxy-service/src/main/java/com/example/bssm_dev/domain/api/service/HealthCheckApiService.java
+++ b/proxy-service/src/main/java/com/example/bssm_dev/domain/api/service/HealthCheckApiService.java
@@ -1,5 +1,6 @@
 package com.example.bssm_dev.domain.api.service;
 
+import com.example.bssm_dev.common.util.DomainValidator;
 import com.example.bssm_dev.domain.api.dto.response.ApiHealthCheckResponse;
 import com.example.bssm_dev.domain.api.executor.ApiRequestExecutor;
 import com.example.bssm_dev.domain.api.model.vo.RequestInfo;
@@ -12,6 +13,9 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class HealthCheckApiService {
     public Mono<ApiHealthCheckResponse> check(String endpoint, String method, String domain, ServerHttpRequest request, byte[] body) {
+        // SSRF 방어: /healthy 엔드포인트는 인증 없이 임의 domain을 지정할 수 있으므로 반드시 검증
+        DomainValidator.validate(domain);
+
         RequestInfo requestInfo = RequestInfo.of(request, body);
         return ApiRequestExecutor.request(endpoint, method, domain, requestInfo)
                 .map(response -> {


### PR DESCRIPTION
- http://, file:// 등 비-https scheme 차단
- 127.x, 10.x, 172.16-31.x, 192.168.x, 169.254.x (AWS 메타데이터 포함), 100.64.x IP 대역 차단
- IPv4/IPv6 직접 입력 차단
- localhost, *.local, *.internal, *.corp, *.lan hostname 패턴 차단
- DNS 해석 후 resolved IP가 내부 대역이면 차단 (DNS rebinding 방어)
- DNS 해석 실패 시 차단