### PR TITLE
chore :: workflow_dispatch 수동 트리거 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,16 @@ on:
     branches:
       - 'release-*'
       - 'dev-*'
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: '배포 환경'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - staging
+          - prod
 
 env:
   APP_IMAGE: donghyunking/bssm-dev-app
@@ -18,7 +28,9 @@ jobs:
       - name: Set deployment environment
         id: set-env
         run: |
-          if [[ "${{ github.ref_name }}" == release-* ]]; then
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "env=${{ github.event.inputs.environment }}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.ref_name }}" == release-* ]]; then
             echo "env=prod" >> $GITHUB_OUTPUT
           else
             echo "env=staging" >> $GITHUB_OUTPUT


### PR DESCRIPTION
push 이벤트가 간헐적으로 동작하지 않을 때 GitHub Actions 탭에서
수동으로 배포 환경을 선택해 트리거할 수 있도록 추가