### PR TITLE
fix :: springdoc /v3/api-docs 경로 permitAll 패턴 수정

### DIFF
--- a/app/src/main/java/com/example/bssm_dev/global/config/SecurityConfig.java
+++ b/app/src/main/java/com/example/bssm_dev/global/config/SecurityConfig.java
@@ -125,7 +125,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/proxy-browser/**").permitAll()
                         .requestMatchers("/api/healthy/**").permitAll()
                         .requestMatchers("/api/token/client/**").permitAll()
-                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                        .requestMatchers("/v3/api-docs", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
/v3/api-docs/** 패턴이 trailing slash 없는 경로를 매칭 못해서 401 발생