### PR TITLE
fix :: springdoc 버전 2.6.0 → 2.8.9 업그레이드

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation "org.springframework.cloud:spring-cloud-starter-openfeign"
     implementation "io.github.openfeign.form:feign-form-spring:3.8.0"
     implementation 'org.apache.httpcomponents.client5:httpclient5'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
Spring Boot 3.5.4 (Spring Framework 6.2.x)와 버전 불일치로 NoSuchMethodError: ControllerAdviceBean.<init>(Object) 발생