### PR TITLE
feat :: endpoint-parser 연동 및 Api SCD Type 2 구조 개선

### DIFF
--- a/app/src/main/java/com/example/bssm_dev/domain/api/controller/query/ApiUsageQueryController.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/controller/query/ApiUsageQueryController.java
@@ -24,14 +24,14 @@ public class ApiUsageQueryController {
     /**
      * 본인이 등록한 API에 대한 사용 목록 조회
      */
-    @GetMapping("/by-api/{apiId}")
-    public ResponseEntity<ResponseDto<CursorPage<ApiUsageResponse>>> getApiUsagesByApiId(
+    @GetMapping("/by-api/{apiGroupId}")
+    public ResponseEntity<ResponseDto<CursorPage<ApiUsageResponse>>> getApiUsagesByApiGroupId(
             @CurrentUser User user,
-            @PathVariable String apiId,
+            @PathVariable String apiGroupId,
             @RequestParam(required = false) Long cursor,
             @RequestParam(required = false, defaultValue = "20") Integer size
     ) {
-        CursorPage<ApiUsageResponse> response = apiUsageQueryService.getApiUsagesByApiId(user, apiId, cursor, size);
+        CursorPage<ApiUsageResponse> response = apiUsageQueryService.getApiUsagesByApiGroupId(user, apiGroupId, cursor, size);
         ResponseDto<CursorPage<ApiUsageResponse>> responseDto = HttpUtil.success("Successfully retrieved API usage requests", response);
         return ResponseEntity.ok(responseDto);
     }

--- a/app/src/main/java/com/example/bssm_dev/domain/api/mapper/ApiTokenMapper.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/mapper/ApiTokenMapper.java
@@ -73,14 +73,18 @@ public class ApiTokenMapper {
 
     public ApiTokenWithDocsResponse toApiTokenWithDocsResponse(
             ApiToken apiToken,
-            Map<String, ContentDocsPage> pageMap
+            Map<String, ContentDocsPage> pageMap,
+            Map<String, String> groupIdToApiId
     ) {
         List<String> origins = apiToken.getTokenDomains().stream()
                 .map(tokenDomain -> tokenDomain.getOrigin())
                 .toList();
 
         List<ApiUsageWithDocsResponse> registeredApis = apiToken.getApiUsageList().stream()
-                .map(usage -> toApiUsageWithDocsResponse(usage, pageMap.get(usage.getApiId())))
+                .map(usage -> {
+                    String apiId = groupIdToApiId.get(usage.getApiGroupId());
+                    return toApiUsageWithDocsResponse(usage, apiId != null ? pageMap.get(apiId) : null);
+                })
                 .toList();
 
         return new ApiTokenWithDocsResponse(
@@ -102,7 +106,7 @@ public class ApiTokenMapper {
                 : List.of();
 
         return new ApiUsageWithDocsResponse(
-                usage.getApiId(),
+                usage.getApiGroupId(),
                 usage.getName(),
                 usage.getEndpoint(),
                 usage.getMethod(),

--- a/app/src/main/java/com/example/bssm_dev/domain/api/mapper/ApiUsageMapper.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/mapper/ApiUsageMapper.java
@@ -27,7 +27,7 @@ public class ApiUsageMapper {
     public ApiUsageResponse toResponse(ApiUsage apiUsage) {
         return new ApiUsageResponse(
                 apiUsage.getApiTokenId(),
-                apiUsage.getApiId(),
+                apiUsage.getApiGroupId(),
                 apiUsage.getName(),
                 apiUsage.getEndpoint(),
                 apiUsage.getName(),
@@ -45,7 +45,7 @@ public class ApiUsageMapper {
     
     public ApiUsageSummaryResponse toSummaryResponse(ApiUsage apiUsage) {
         return new ApiUsageSummaryResponse(
-                apiUsage.getApiId(),
+                apiUsage.getApiGroupId(),
                 apiUsage.getName(),
                 apiUsage.getEndpoint(),
                 apiUsage.getMethod(),

--- a/app/src/main/java/com/example/bssm_dev/domain/api/model/Api.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/model/Api.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,6 +20,10 @@ public class Api {
     @Id
     @Column(length = 500)
     private String apiId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "api_group_id", nullable = false)
+    private ApiGroup apiGroup;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "creator_id", nullable = false)
@@ -40,17 +45,29 @@ public class Api {
     @Column(columnDefinition = "BOOLEAN DEFAULT FALSE")
     private Boolean autoApproval;
 
-    @OneToMany(mappedBy = "api", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Column(nullable = false)
     @Builder.Default
-    private List<ApiUsage> apiUsage = new ArrayList<>();
+    private Integer version = 1;
+
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT TRUE")
+    @Builder.Default
+    private Boolean isCurrent = true;
+
+    @Column(nullable = false)
+    private LocalDateTime validFrom;
+
+    private LocalDateTime validTo;
+
+    private Long githubRepositoryId;
 
     @OneToMany(mappedBy = "api", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<ApiUseReason> apiUseReason = new ArrayList<>();
 
-    public static Api of(String apiId, User creator, String endpoint, String method, String name, String domain, String repositoryUrl, Boolean autoApproval) {
+    public static Api createNew(String apiId, ApiGroup apiGroup, User creator, String endpoint, String method, String name, String domain, String repositoryUrl, Boolean autoApproval) {
         return Api.builder()
                 .apiId(apiId)
+                .apiGroup(apiGroup)
                 .creator(creator)
                 .endpoint(endpoint)
                 .method(method)
@@ -58,9 +75,33 @@ public class Api {
                 .domain(domain)
                 .repositoryUrl(repositoryUrl)
                 .autoApproval(autoApproval != null ? autoApproval : false)
+                .version(1)
+                .isCurrent(true)
+                .validFrom(LocalDateTime.now())
+                .validTo(null)
                 .build();
     }
 
+    public Api nextVersion(String newApiId) {
+        this.validTo = LocalDateTime.now();
+        this.isCurrent = false;
+        return Api.builder()
+                .apiId(newApiId)
+                .apiGroup(this.apiGroup)
+                .creator(this.creator)
+                .endpoint(this.endpoint)
+                .method(this.method)
+                .name(this.name)
+                .domain(this.domain)
+                .repositoryUrl(this.repositoryUrl)
+                .autoApproval(this.autoApproval)
+                .version(this.version + 1)
+                .isCurrent(true)
+                .validFrom(LocalDateTime.now())
+                .validTo(null)
+                .githubRepositoryId(this.githubRepositoryId)
+                .build();
+    }
 
     public void updateApiInfo(String endpoint, String method, String name, String domain) {
         this.endpoint = endpoint;

--- a/app/src/main/java/com/example/bssm_dev/domain/api/model/ApiGroup.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/model/ApiGroup.java
@@ -1,0 +1,25 @@
+package com.example.bssm_dev.domain.api.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class ApiGroup {
+
+    @Id
+    @Column(length = 500)
+    private String apiGroupId;
+
+    private ApiGroup(String apiGroupId) {
+        this.apiGroupId = apiGroupId;
+    }
+
+    public static ApiGroup of(String apiGroupId) {
+        return new ApiGroup(apiGroupId);
+    }
+}

--- a/app/src/main/java/com/example/bssm_dev/domain/api/model/ApiToken.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/model/ApiToken.java
@@ -110,7 +110,7 @@ public class ApiToken {
 
     public boolean checkApiUsage(Api api) {
         return this.apiUsageList.stream()
-                .anyMatch(apiUsage -> apiUsage.equalsApi(api));
+                .anyMatch(apiUsage -> apiUsage.equalsApiGroup(api.getApiGroup()));
     }
 
     public boolean isOwner(User user) {

--- a/app/src/main/java/com/example/bssm_dev/domain/api/model/ApiUsage.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/model/ApiUsage.java
@@ -21,9 +21,9 @@ public class ApiUsage {
     private ApiToken apiToken;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @MapsId("apiId")
-    @JoinColumn(name = "api_id", nullable = false)
-    private Api api;
+    @MapsId("apiGroupId")
+    @JoinColumn(name = "api_group_id", nullable = false)
+    private ApiGroup apiGroup;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "api_use_reason_id", nullable = false)
@@ -35,14 +35,18 @@ public class ApiUsage {
     @Column(nullable = false)
     private String endpoint;
 
+    @Column(length = 15, nullable = false)
+    private String method;
+
     public static ApiUsage of(ApiToken apiToken, Api api, ApiUseReason apiUseReason, String name, String endpoint) {
         return ApiUsage.builder()
-                .id(new ApiUsageId(apiToken.getApiTokenId(), api.getApiId()))
+                .id(new ApiUsageId(apiToken.getApiTokenId(), api.getApiGroup().getApiGroupId()))
                 .apiToken(apiToken)
-                .api(api)
+                .apiGroup(api.getApiGroup())
                 .apiUseReason(apiUseReason)
                 .name(name)
                 .endpoint(endpoint)
+                .method(api.getMethod())
                 .build();
     }
 
@@ -54,12 +58,8 @@ public class ApiUsage {
         this.endpoint = endpoint;
     }
 
-    public String getApiId() {
-        return api.getApiId();
-    }
-
-    public String getMethod() {
-        return api.getMethod();
+    public String getApiGroupId() {
+        return apiGroup.getApiGroupId();
     }
 
     public Long getApiTokenId() {
@@ -74,7 +74,7 @@ public class ApiUsage {
         return apiUseReason.getApiUseState();
     }
 
-    public boolean equalsApi(Api api) {
-        return this.api.equals(api);
+    public boolean equalsApiGroup(ApiGroup apiGroup) {
+        return this.apiGroup.equals(apiGroup);
     }
 }

--- a/app/src/main/java/com/example/bssm_dev/domain/api/model/key/ApiUsageId.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/model/key/ApiUsageId.java
@@ -15,9 +15,9 @@ import java.io.Serializable;
 @EqualsAndHashCode
 public class ApiUsageId implements Serializable {
     private Long apiTokenId;
-    private String apiId;
+    private String apiGroupId;
 
-    public static ApiUsageId create(String apiId, Long apiTokenId) {
-        return new ApiUsageId(apiTokenId, apiId);
+    public static ApiUsageId create(String apiGroupId, Long apiTokenId) {
+        return new ApiUsageId(apiTokenId, apiGroupId);
     }
 }

--- a/app/src/main/java/com/example/bssm_dev/domain/api/repository/ApiGroupRepository.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/repository/ApiGroupRepository.java
@@ -1,0 +1,9 @@
+package com.example.bssm_dev.domain.api.repository;
+
+import com.example.bssm_dev.domain.api.model.ApiGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApiGroupRepository extends JpaRepository<ApiGroup, String> {
+}

--- a/app/src/main/java/com/example/bssm_dev/domain/api/repository/ApiRepository.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/repository/ApiRepository.java
@@ -2,9 +2,28 @@ package com.example.bssm_dev.domain.api.repository;
 
 import com.example.bssm_dev.domain.api.model.Api;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ApiRepository extends JpaRepository<Api, String>, QuerydslPredicateExecutor<Api> {
+
+    Optional<Api> findByApiGroupApiGroupIdAndIsCurrentTrue(String apiGroupId);
+
+    List<Api> findByApiGroupApiGroupIdInAndIsCurrentTrue(Collection<String> apiGroupIds);
+
+    Optional<Api> findByApiGroupApiGroupIdAndEndpointAndMethodAndIsCurrentTrue(String apiGroupId, String endpoint, String method);
+
+    @Query("SELECT a FROM Api a WHERE a.githubRepositoryId = :repoId AND a.endpoint = :endpoint AND a.method = :method AND a.isCurrent = true")
+    Optional<Api> findCurrentApiByRepoAndEndpointAndMethod(
+            @Param("repoId") Long repoId,
+            @Param("endpoint") String endpoint,
+            @Param("method") String method
+    );
 }

--- a/app/src/main/java/com/example/bssm_dev/domain/api/repository/ApiUsageRepository.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/repository/ApiUsageRepository.java
@@ -18,28 +18,28 @@ public interface ApiUsageRepository extends JpaRepository<ApiUsage, ApiUsageId> 
 
     Optional<ApiUsage> findByApiTokenAndEndpoint(ApiToken apiToken, String endpoint);
     
-    @Query("SELECT au FROM ApiUsage au JOIN FETCH au.api a WHERE au.apiToken = :apiToken AND au.endpoint LIKE CONCAT(:endpointPrefix, '%') AND a.method = :method")
+    @Query("SELECT au FROM ApiUsage au WHERE au.apiToken = :apiToken AND au.endpoint LIKE CONCAT(:endpointPrefix, '%') AND au.method = :method")
     List<ApiUsage> findCandidatesByPrefixAndMethod(
-            @Param("apiToken") ApiToken apiToken, 
-            @Param("endpointPrefix") String endpointPrefix, 
+            @Param("apiToken") ApiToken apiToken,
+            @Param("endpointPrefix") String endpointPrefix,
             @Param("method") String method
     );
-    
+
     @Query("SELECT au FROM ApiUsage au " +
            "JOIN FETCH au.apiToken at " +
-           "JOIN FETCH au.api a " +
+           "JOIN FETCH au.apiGroup ag " +
            "JOIN FETCH au.apiUseReason aur " +
            "WHERE at.user.userId = :userId " +
            "AND au.id.apiTokenId < COALESCE(:cursor, 9223372036854775807) " +
-           "ORDER BY au.id.apiTokenId DESC, au.id.apiId DESC")
+           "ORDER BY au.id.apiTokenId DESC, au.id.apiGroupId DESC")
     Slice<ApiUsage> findAllByUserIdWithCursor(
-            @Param("userId") Long userId, 
-            @Param("cursor") Long cursor, 
+            @Param("userId") Long userId,
+            @Param("cursor") Long cursor,
             Pageable pageable
     );
-    
+
     @Query("SELECT au FROM ApiUsage au " +
-           "JOIN FETCH au.api a " +
+           "JOIN FETCH au.apiGroup ag " +
            "JOIN FETCH au.apiUseReason aur " +
            "WHERE au.apiToken = :apiToken")
     List<ApiUsage> findAllByApiToken(@Param("apiToken") ApiToken apiToken);
@@ -48,11 +48,11 @@ public interface ApiUsageRepository extends JpaRepository<ApiUsage, ApiUsageId> 
            "JOIN FETCH au.apiToken at " +
            "JOIN FETCH at.user u " +
            "JOIN FETCH au.apiUseReason aur " +
-           "WHERE au.api.apiId = :apiId " +
+           "WHERE au.apiGroup.apiGroupId = :apiGroupId " +
            "AND au.id.apiTokenId < COALESCE(:cursor, 9223372036854775807) " +
            "ORDER BY au.id.apiTokenId DESC")
-    Slice<ApiUsage> findAllByApiIdWithCursor(
-            @Param("apiId") String apiId,
+    Slice<ApiUsage> findAllByApiGroupIdWithCursor(
+            @Param("apiGroupId") String apiGroupId,
             @Param("cursor") Long cursor,
             Pageable pageable
     );

--- a/app/src/main/java/com/example/bssm_dev/domain/api/service/command/ApiCommandService.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/service/command/ApiCommandService.java
@@ -2,6 +2,8 @@ package com.example.bssm_dev.domain.api.service.command;
 
 import com.example.bssm_dev.common.util.DomainValidator;
 import com.example.bssm_dev.domain.api.model.Api;
+import com.example.bssm_dev.domain.api.model.ApiGroup;
+import com.example.bssm_dev.domain.api.repository.ApiGroupRepository;
 import com.example.bssm_dev.domain.api.repository.ApiRepository;
 import com.example.bssm_dev.domain.docs.model.ContentDocsPage;
 import com.example.bssm_dev.domain.docs.model.DocsPage;
@@ -16,12 +18,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ApiCommandService {
     private final ApiRepository apiRepository;
+    private final ApiGroupRepository apiGroupRepository;
     private final TryItTokenCommandService tryItTokenCommandService;
 
     @Transactional("transactionManager")
@@ -80,8 +84,10 @@ public class ApiCommandService {
                 if (docsPage != null && docsPage.getEndpoint() != null) {
                     log.info("DocsPage found for mappedId={}: id={}, endpoint={}",
                             block.getMappedId(), docsPage.getId(), docsPage.getEndpoint());
-                    Api api = Api.of(
-                            docsPage.getId(),  // DocsPage의 id를 apiId로 사용
+                    ApiGroup apiGroup = apiGroupRepository.save(ApiGroup.of(UUID.randomUUID().toString()));
+                    Api api = Api.createNew(
+                            docsPage.getId(),  // DocsPage의 id를 apiId로 사용 (v1)
+                            apiGroup,
                             creator,
                             docsPage.getEndpoint(),
                             block.getMethod(),

--- a/app/src/main/java/com/example/bssm_dev/domain/api/service/query/ApiQueryService.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/service/query/ApiQueryService.java
@@ -15,4 +15,9 @@ public class ApiQueryService {
         return apiRepository.findById(apiId)
                 .orElseThrow(ApiNotFoundException::raise);
     }
+
+    public Api findCurrentByApiGroupId(String apiGroupId) {
+        return apiRepository.findByApiGroupApiGroupIdAndIsCurrentTrue(apiGroupId)
+                .orElseThrow(ApiNotFoundException::raise);
+    }
 }

--- a/app/src/main/java/com/example/bssm_dev/domain/api/service/query/ApiTokenQueryService.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/service/query/ApiTokenQueryService.java
@@ -8,7 +8,10 @@ import com.example.bssm_dev.domain.api.dto.response.SecretApiTokenResponse;
 import com.example.bssm_dev.domain.api.exception.UnauthorizedApiTokenAccessException;
 import com.example.bssm_dev.domain.api.exception.ApiTokenNotFoundException;
 import com.example.bssm_dev.domain.api.mapper.ApiTokenMapper;
+import com.example.bssm_dev.domain.api.model.Api;
 import com.example.bssm_dev.domain.api.model.ApiToken;
+import com.example.bssm_dev.domain.api.model.ApiUsage;
+import com.example.bssm_dev.domain.api.repository.ApiRepository;
 import com.example.bssm_dev.domain.api.repository.ApiTokenRepository;
 import com.example.bssm_dev.domain.docs.model.ContentDocsPage;
 import com.example.bssm_dev.domain.docs.model.DocsPage;
@@ -31,6 +34,7 @@ import java.util.stream.Collectors;
 public class ApiTokenQueryService {
     private final ApiTokenRepository apiTokenRepository;
     private final ApiTokenMapper apiTokenMapper;
+    private final ApiRepository apiRepository;
     private final DocsPageRepository docsPageRepository;
 
     public ApiToken findById(Long apiTokenId) {
@@ -73,15 +77,25 @@ public class ApiTokenQueryService {
         ApiToken apiToken = apiTokenRepository.findByTokenUUID(clientId)
                 .orElseThrow(ApiTokenNotFoundException::raise);
 
-        List<String> apiIds = apiToken.getApiUsageList().stream()
-                .map(usage -> usage.getApiId())
+        List<String> apiGroupIds = apiToken.getApiUsageList().stream()
+                .map(ApiUsage::getApiGroupId)
                 .toList();
 
-        Map<String, ContentDocsPage> pageMap = docsPageRepository.findAllById(apiIds).stream()
+        // apiGroupId → 현재 버전 apiId 매핑 (배치 조회)
+        Map<String, String> groupIdToApiId = apiRepository.findByApiGroupApiGroupIdInAndIsCurrentTrue(apiGroupIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        api -> api.getApiGroup().getApiGroupId(),
+                        Api::getApiId
+                ));
+
+        List<String> currentApiIds = List.copyOf(groupIdToApiId.values());
+
+        Map<String, ContentDocsPage> pageMap = docsPageRepository.findAllById(currentApiIds).stream()
                 .filter(p -> p instanceof ContentDocsPage)
                 .map(p -> (ContentDocsPage) p)
                 .collect(Collectors.toMap(DocsPage::getId, p -> p));
 
-        return apiTokenMapper.toApiTokenWithDocsResponse(apiToken, pageMap);
+        return apiTokenMapper.toApiTokenWithDocsResponse(apiToken, pageMap, groupIdToApiId);
     }
 }

--- a/app/src/main/java/com/example/bssm_dev/domain/api/service/query/ApiUsageQueryService.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/service/query/ApiUsageQueryService.java
@@ -22,19 +22,19 @@ public class ApiUsageQueryService {
     private final ApiUsageRepository apiUsageRepository;
     private final ApiUsageMapper apiUsageMapper;
     private final ApiQueryService apiQueryService;
-    public CursorPage<ApiUsageResponse> getApiUsagesByApiId(User user, String apiId, Long cursor, Integer size) {
-        Api api = apiQueryService.findById(apiId);
+    public CursorPage<ApiUsageResponse> getApiUsagesByApiGroupId(User user, String apiGroupId, Long cursor, Integer size) {
+        Api api = apiQueryService.findCurrentByApiGroupId(apiGroupId);
 
         boolean isApiCreator = api.isCreator(user);
         if (!isApiCreator) {
             throw UnauthorizedApiUsageAccessException.raise();
         }
-        
+
         Pageable pageable = PageRequest.of(0, size);
-        Slice<ApiUsage> apiUsageSlice = apiUsageRepository.findAllByApiIdWithCursor(apiId, cursor, pageable);
-        
+        Slice<ApiUsage> apiUsageSlice = apiUsageRepository.findAllByApiGroupIdWithCursor(apiGroupId, cursor, pageable);
+
         List<ApiUsageResponse> responses = apiUsageMapper.toListResponse(apiUsageSlice);
-        
+
         return new CursorPage<>(responses, apiUsageSlice.hasNext());
     }
 }

--- a/app/src/main/java/com/example/bssm_dev/domain/github/dto/request/EndpointParseRequest.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/dto/request/EndpointParseRequest.java
@@ -1,0 +1,7 @@
+package com.example.bssm_dev.domain.github.dto.request;
+
+public record EndpointParseRequest(
+        String repoFullName,
+        String branch,
+        String installationToken
+) {}

--- a/app/src/main/java/com/example/bssm_dev/domain/github/dto/response/EndpointParseResponse.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/dto/response/EndpointParseResponse.java
@@ -1,0 +1,12 @@
+package com.example.bssm_dev.domain.github.dto.response;
+
+import java.util.List;
+
+public record EndpointParseResponse(
+        List<ParsedEndpoint> endpoints
+) {
+    public record ParsedEndpoint(
+            String method,
+            String path
+    ) {}
+}

--- a/app/src/main/java/com/example/bssm_dev/domain/github/repository/GitHubRepositoryRepository.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/repository/GitHubRepositoryRepository.java
@@ -10,4 +10,5 @@ public interface GitHubRepositoryRepository extends JpaRepository<GitHubReposito
     List<GitHubRepository> findAllByUserId(Long userId);
     Optional<GitHubRepository> findByIdAndUserId(Long id, Long userId);
     boolean existsByUserIdAndRepoFullNameAndBranch(Long userId, String repoFullName, String branch);
+    List<GitHubRepository> findAllByRepoFullNameAndBranch(String repoFullName, String branch);
 }

--- a/app/src/main/java/com/example/bssm_dev/domain/github/service/EndpointSyncService.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/service/EndpointSyncService.java
@@ -1,0 +1,128 @@
+package com.example.bssm_dev.domain.github.service;
+
+import com.example.bssm_dev.domain.api.model.Api;
+import com.example.bssm_dev.domain.api.model.ApiGroup;
+import com.example.bssm_dev.domain.api.repository.ApiGroupRepository;
+import com.example.bssm_dev.domain.api.repository.ApiRepository;
+import com.example.bssm_dev.domain.github.dto.request.EndpointParseRequest;
+import com.example.bssm_dev.domain.github.dto.response.EndpointParseResponse;
+import com.example.bssm_dev.domain.github.model.GitHubConnection;
+import com.example.bssm_dev.domain.github.model.GitHubRepository;
+import com.example.bssm_dev.domain.github.repository.GitHubConnectionRepository;
+import com.example.bssm_dev.domain.github.repository.GitHubRepositoryRepository;
+import com.example.bssm_dev.domain.user.model.User;
+import com.example.bssm_dev.domain.user.repository.UserRepository;
+import com.example.bssm_dev.global.component.GitHubInstallationTokenProvider;
+import com.example.bssm_dev.global.feign.EndpointParserFeign;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EndpointSyncService {
+
+    private final EndpointParserFeign endpointParserFeign;
+    private final GitHubInstallationTokenProvider installationTokenProvider;
+    private final GitHubRepositoryRepository gitHubRepositoryRepository;
+    private final GitHubConnectionRepository gitHubConnectionRepository;
+    private final ApiRepository apiRepository;
+    private final ApiGroupRepository apiGroupRepository;
+    private final UserRepository userRepository;
+
+    @Transactional("transactionManager")
+    public void syncOnPush(String repoFullName, String branch, Long installationId) {
+        List<GitHubRepository> registeredRepos = gitHubRepositoryRepository
+                .findAllByRepoFullNameAndBranch(repoFullName, branch);
+
+        if (registeredRepos.isEmpty()) {
+            log.debug("no registered repos for {}/{}", repoFullName, branch);
+            return;
+        }
+
+        String installationToken;
+        try {
+            installationToken = installationTokenProvider.getInstallationToken(installationId);
+        } catch (Exception e) {
+            log.error("failed to get installation token for installationId={}", installationId, e);
+            return;
+        }
+
+        EndpointParseResponse parsed;
+        try {
+            parsed = endpointParserFeign.parse(
+                    new EndpointParseRequest(repoFullName, branch, installationToken)
+            );
+        } catch (Exception e) {
+            log.error("endpoint-parser call failed for {}/{}", repoFullName, branch, e);
+            return;
+        }
+
+        if (parsed == null || parsed.endpoints() == null || parsed.endpoints().isEmpty()) {
+            log.info("no endpoints parsed for {}/{}", repoFullName, branch);
+            return;
+        }
+
+        for (GitHubRepository repo : registeredRepos) {
+            syncApiVersions(repo, parsed.endpoints());
+        }
+    }
+
+    private void syncApiVersions(GitHubRepository repo, List<EndpointParseResponse.ParsedEndpoint> parsedEndpoints) {
+        GitHubConnection connection = gitHubConnectionRepository.findByInstallationId(repo.getInstallationId())
+                .orElse(null);
+        if (connection == null) {
+            return;
+        }
+
+        Optional<User> creatorOpt = userRepository.findById(repo.getUserId());
+        if (creatorOpt.isEmpty()) {
+            return;
+        }
+        User creator = creatorOpt.get();
+
+        for (EndpointParseResponse.ParsedEndpoint parsed : parsedEndpoints) {
+            Optional<Api> existingOpt = apiRepository
+                    .findCurrentApiByRepoAndEndpointAndMethod(repo.getId(), parsed.path(), parsed.method());
+
+            if (existingOpt.isPresent()) {
+                Api existing = existingOpt.get();
+                // 내용 변경이 없으면 skip
+                if (existing.getEndpoint().equals(parsed.path()) && existing.getMethod().equals(parsed.method())) {
+                    continue;
+                }
+                // 변경된 경우 새 버전 생성
+                Api next = existing.nextVersion(UUID.randomUUID().toString());
+                apiRepository.save(existing);
+                apiRepository.save(next);
+                log.info("api version bumped: group={} v{} -> v{}", existing.getApiGroup().getApiGroupId(),
+                        existing.getVersion(), next.getVersion());
+            } else {
+                // 신규 엔드포인트
+                ApiGroup group = apiGroupRepository.save(ApiGroup.of(UUID.randomUUID().toString()));
+                Api newApi = Api.builder()
+                        .apiId(UUID.randomUUID().toString())
+                        .apiGroup(group)
+                        .creator(creator)
+                        .endpoint(parsed.path())
+                        .method(parsed.method())
+                        .name(parsed.method() + " " + parsed.path())
+                        .version(1)
+                        .isCurrent(true)
+                        .validFrom(LocalDateTime.now())
+                        .githubRepositoryId(repo.getId())
+                        .autoApproval(false)
+                        .build();
+                apiRepository.save(newApi);
+                log.info("new api registered: {} {}", parsed.method(), parsed.path());
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/bssm_dev/domain/github/service/GitHubWebhookService.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/service/GitHubWebhookService.java
@@ -31,6 +31,7 @@ public class GitHubWebhookService {
     private final GitHubConnectionRepository gitHubConnectionRepository;
     private final GitHubAppProperties gitHubAppProperties;
     private final ObjectMapper objectMapper;
+    private final EndpointSyncService endpointSyncService;
 
     @Transactional("transactionManager")
     public void handle(String event, String signature, String payload) {
@@ -84,7 +85,7 @@ public class GitHubWebhookService {
 
             log.info("github push event - repo={}, branch={}, githubLogin={}", repoFullName, branch, connection.getGithubLogin());
 
-            // TODO: 브랜치별 비즈니스 로직 추가
+            endpointSyncService.syncOnPush(repoFullName, branch, installationId);
         } catch (GitHubConnectionNotFoundException e) {
             log.warn("received push event but no matching github connection found for installationId");
         } catch (Exception e) {

--- a/app/src/main/java/com/example/bssm_dev/global/feign/EndpointParserFeign.java
+++ b/app/src/main/java/com/example/bssm_dev/global/feign/EndpointParserFeign.java
@@ -1,0 +1,14 @@
+package com.example.bssm_dev.global.feign;
+
+import com.example.bssm_dev.domain.github.dto.request.EndpointParseRequest;
+import com.example.bssm_dev.domain.github.dto.response.EndpointParseResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "endpointParser", url = "${endpoint-parser.url}")
+public interface EndpointParserFeign {
+
+    @PostMapping("/parse")
+    EndpointParseResponse parse(@RequestBody EndpointParseRequest request);
+}


### PR DESCRIPTION
- ApiGroup 엔티티 추가: ApiUsage의 안정적인 FK 역할 (SCD Type 2)
- Api 엔티티 버전 관리: isLatest 플래그 및 ApiGroup 참조
- EndpointParserFeign: endpoint-parser 서비스 호출 클라이언트
- EndpointSyncService: 웹훅 이벤트 수신 시 엔드포인트 자동 동기화
- ApiUsage/ApiToken 관련 mapper, service, repository 업데이트