### PR TITLE
feat :: 문서 생성 시 AST 파싱된 엔드포인트 검증 및 파싱 목록 조회 API 추가

### DIFF
--- a/app/src/main/java/com/example/bssm_dev/domain/api/repository/ApiRepository.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/repository/ApiRepository.java
@@ -26,4 +26,9 @@ public interface ApiRepository extends JpaRepository<Api, String>, QuerydslPredi
             @Param("endpoint") String endpoint,
             @Param("method") String method
     );
+
+    List<Api> findAllByGithubRepositoryIdAndIsCurrentTrue(Long githubRepositoryId);
+
+    boolean existsByGithubRepositoryIdAndEndpointAndMethodAndIsCurrentTrue(
+            Long githubRepositoryId, String endpoint, String method);
 }

--- a/app/src/main/java/com/example/bssm_dev/domain/api/repository/ApiTokenRepository.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/repository/ApiTokenRepository.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 @Repository
 public interface ApiTokenRepository extends JpaRepository<ApiToken, Long> {
 
-    @EntityGraph(attributePaths = {"apiUsageList", "apiUsageList.api", "apiUsageList.apiUseReason"})
+    @EntityGraph(attributePaths = {"apiUsageList", "apiUsageList.apiGroup", "apiUsageList.apiUseReason"})
     @Query("SELECT at FROM ApiToken at WHERE at.user.userId = :userId AND at.apiTokenId < COALESCE(:cursor, 9223372036854775807) ORDER BY at.apiTokenId DESC")
     Slice<ApiToken> findAllByUserIdWithCursorOrderByApiTokenIdDesc(@Param("userId") Long userId, @Param("cursor") Long cursor, Pageable pageable);
 

--- a/app/src/main/java/com/example/bssm_dev/domain/docs/dto/request/CreateDocsPageRequest.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/docs/dto/request/CreateDocsPageRequest.java
@@ -9,6 +9,7 @@ public record CreateDocsPageRequest (
         String id,
         List<DocsPageBlockRequest> blocks,
         String endpoint,      // original docs API 페이지인 경우에만 존재
+        String method,        // original docs API 페이지인 경우에만 존재 (endpoint와 함께 사용)
         String sourceDocsId,  // 커스텀 docs API 참조 페이지인 경우에만 존재
         String sourceMappedId // 커스텀 docs API 참조 페이지인 경우에만 존재
 ) {

--- a/app/src/main/java/com/example/bssm_dev/domain/docs/mapper/DocsPageMapper.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/docs/mapper/DocsPageMapper.java
@@ -35,6 +35,7 @@ public class DocsPageMapper {
                         ? docsPageBlockMapper.toDocsPageBlocks(request.blocks())
                         : List.of())
                 .endpoint(request.endpoint())
+                .method(request.method())
                 .build();
     }
 

--- a/app/src/main/java/com/example/bssm_dev/domain/docs/model/ContentDocsPage.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/docs/model/ContentDocsPage.java
@@ -16,6 +16,7 @@ import java.util.List;
 public class ContentDocsPage extends DocsPage {
     private List<DocsPageBlock> docsBlocks;
     private String endpoint;
+    private String method;
 
     public void updateDocsBlocks(List<DocsPageBlock> docsBlocks) {
         this.docsBlocks = docsBlocks;

--- a/app/src/main/java/com/example/bssm_dev/domain/docs/service/command/DocsCommandService.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/docs/service/command/DocsCommandService.java
@@ -1,5 +1,6 @@
 package com.example.bssm_dev.domain.docs.service.command;
 
+import com.example.bssm_dev.domain.api.repository.ApiRepository;
 import com.example.bssm_dev.domain.docs.dto.request.CreateCustomDocsRequest;
 import com.example.bssm_dev.domain.docs.dto.request.DocsCreateRequest;
 import com.example.bssm_dev.domain.docs.dto.request.DocsUpdateRequest;
@@ -35,12 +36,15 @@ public class DocsCommandService {
     private final DocsSideBarCommandService docsSideBarCommandService;
     private final DocsPageCommandService docsPageCommandService;
     private final GitHubRepositoryQueryService gitHubRepositoryQueryService;
+    private final ApiRepository apiRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
 
     public void createOriginalDocs(DocsCreateRequest request, User creator) {
         validateTitleUnique(request.title());
         GitHubRepository gitHubRepository = gitHubRepositoryQueryService
                 .getRepositoryForDocs(creator.getUserId(), request.githubRepositoryId());
+
+        DocsValidator.checkParsedEndpointsExist(request.docsPages(), gitHubRepository.getId(), apiRepository);
 
         Docs docs = docsMapper.toOriginalDocs(request, creator, gitHubRepository);
         Docs newDocs = docsRepository.save(docs);
@@ -89,6 +93,8 @@ public class DocsCommandService {
 
         GitHubRepository gitHubRepository = gitHubRepositoryQueryService
                 .getRepositoryForDocs(user.getUserId(), request.githubRepositoryId());
+
+        DocsValidator.checkParsedEndpointsExist(request.docsPages(), gitHubRepository.getId(), apiRepository);
 
         docs.updateDocs(
                 request.title(),

--- a/app/src/main/java/com/example/bssm_dev/domain/docs/validator/DocsValidator.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/docs/validator/DocsValidator.java
@@ -1,5 +1,7 @@
 package com.example.bssm_dev.domain.docs.validator;
 
+import com.example.bssm_dev.domain.api.exception.EndpointNotFoundException;
+import com.example.bssm_dev.domain.api.repository.ApiRepository;
 import com.example.bssm_dev.domain.docs.dto.request.CreateDocsPageRequest;
 import com.example.bssm_dev.domain.docs.exception.DocsCustomApiPageMustBeReferenceException;
 import com.example.bssm_dev.domain.docs.exception.DocsNotCustomTypeException;
@@ -26,6 +28,19 @@ public class DocsValidator {
                 throw DocsCustomApiPageMustBeReferenceException.raise();
             }
         });
+    }
+
+    public static void checkParsedEndpointsExist(List<CreateDocsPageRequest> requests, Long repoId, ApiRepository apiRepository) {
+        requests.stream()
+                .filter(r -> r.endpoint() != null && r.sourceDocsId() == null)
+                .forEach(r -> {
+                    boolean exists = apiRepository.existsByGithubRepositoryIdAndEndpointAndMethodAndIsCurrentTrue(
+                            repoId, r.endpoint(), r.method()
+                    );
+                    if (!exists) {
+                        throw EndpointNotFoundException.raise();
+                    }
+                });
     }
 //
 //    public static void checkIfIsMyDocs(User user, DocsSection section) {

--- a/app/src/main/java/com/example/bssm_dev/domain/github/controller/GitHubRepositoryController.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/controller/GitHubRepositoryController.java
@@ -6,6 +6,7 @@ import com.example.bssm_dev.common.util.HttpUtil;
 import com.example.bssm_dev.domain.github.dto.request.RegisterGitHubRepoRequest;
 import com.example.bssm_dev.domain.github.dto.response.GitHubBranchItem;
 import com.example.bssm_dev.domain.github.dto.response.GitHubRepoItem;
+import com.example.bssm_dev.domain.github.dto.response.ParsedEndpointResponse;
 import com.example.bssm_dev.domain.github.dto.response.RegisteredRepoResponse;
 import com.example.bssm_dev.domain.github.service.GitHubRepositoryQueryService;
 import com.example.bssm_dev.domain.github.service.GitHubRepositoryService;
@@ -83,5 +84,17 @@ public class GitHubRepositoryController {
     ) {
         gitHubRepositoryService.delete(user.getUserId(), repoId);
         return ResponseEntity.ok(HttpUtil.success("repository unregistered"));
+    }
+
+    /**
+     * 레포지토리에서 AST 파싱된 엔드포인트 목록 조회
+     */
+    @GetMapping("/{repoId}/parsed-endpoints")
+    public ResponseEntity<ResponseDto<List<ParsedEndpointResponse>>> getParsedEndpoints(
+            @CurrentUser User user,
+            @PathVariable Long repoId
+    ) {
+        List<ParsedEndpointResponse> endpoints = gitHubRepositoryQueryService.getParsedEndpoints(user.getUserId(), repoId);
+        return ResponseEntity.ok(HttpUtil.success("parsed endpoints", endpoints));
     }
 }

--- a/app/src/main/java/com/example/bssm_dev/domain/github/dto/response/ParsedEndpointResponse.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/dto/response/ParsedEndpointResponse.java
@@ -1,0 +1,12 @@
+package com.example.bssm_dev.domain.github.dto.response;
+
+import com.example.bssm_dev.domain.api.model.Api;
+
+public record ParsedEndpointResponse(
+        String method,
+        String endpoint
+) {
+    public static ParsedEndpointResponse from(Api api) {
+        return new ParsedEndpointResponse(api.getMethod(), api.getEndpoint());
+    }
+}

--- a/app/src/main/java/com/example/bssm_dev/domain/github/service/GitHubRepositoryQueryService.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/service/GitHubRepositoryQueryService.java
@@ -1,7 +1,9 @@
 package com.example.bssm_dev.domain.github.service;
 
+import com.example.bssm_dev.domain.api.repository.ApiRepository;
 import com.example.bssm_dev.domain.github.dto.response.GitHubBranchItem;
 import com.example.bssm_dev.domain.github.dto.response.GitHubRepoItem;
+import com.example.bssm_dev.domain.github.dto.response.ParsedEndpointResponse;
 import com.example.bssm_dev.domain.github.dto.response.RegisteredRepoResponse;
 import com.example.bssm_dev.domain.github.exception.GitHubAppNotInstalledException;
 import com.example.bssm_dev.domain.github.exception.GitHubConnectionNotFoundException;
@@ -24,6 +26,7 @@ public class GitHubRepositoryQueryService {
     private final GitHubConnectionRepository gitHubConnectionRepository;
     private final GitHubRepositoryRepository gitHubRepositoryRepository;
     private final GitHubApiService gitHubApiService;
+    private final ApiRepository apiRepository;
 
     @Transactional(readOnly = true)
     public List<RegisteredRepoResponse> getRegisteredRepositories(Long userId) {
@@ -52,6 +55,20 @@ public class GitHubRepositoryQueryService {
         }
 
         return repo;
+    }
+
+    @Transactional(readOnly = true)
+    public List<ParsedEndpointResponse> getParsedEndpoints(Long userId, Long repoId) {
+        GitHubRepository repo = gitHubRepositoryRepository.findById(repoId)
+                .orElseThrow(GitHubRepositoryNotFoundException::raise);
+
+        if (!repo.isOwnedBy(userId)) {
+            throw GitHubRepositoryUnauthorizedException.raise();
+        }
+
+        return apiRepository.findAllByGithubRepositoryIdAndIsCurrentTrue(repoId).stream()
+                .map(ParsedEndpointResponse::from)
+                .toList();
     }
 
     private Long getInstallationIdOrThrow(Long userId) {


### PR DESCRIPTION
- GET /github/repositories/{repoId}/parsed-endpoints: 레포에서 파싱된 엔드포인트 목록 조회
- 문서 생성/교체 시 endpoint+method가 파싱된 Api 테이블에 존재하는지 검증
- CreateDocsPageRequest, ContentDocsPage에 method 필드 추가
- fix :: ApiTokenRepository @EntityGraph apiUsageList.api → apiUsageList.apiGroup 수정