### PR TITLE
docs :: GitHub 관련 API OpenAPI 명세 추가

### DIFF
--- a/app/src/main/java/com/example/bssm_dev/domain/github/controller/GitHubOauthController.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/controller/GitHubOauthController.java
@@ -11,6 +11,11 @@ import com.example.bssm_dev.domain.github.service.GitHubConnectionQueryService;
 import com.example.bssm_dev.domain.github.service.GitHubOauthService;
 import com.example.bssm_dev.domain.user.model.User;
 import com.example.bssm_dev.global.config.properties.GitHubAppProperties;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
+@Tag(name = "GitHub OAuth", description = "GitHub 계정 연동 및 연결 상태 API")
 @RestController
 @RequestMapping("/github")
 @RequiredArgsConstructor
@@ -28,6 +34,14 @@ public class GitHubOauthController {
     private final GitHubAppProperties gitHubAppProperties;
     private final CookieUtil cookieUtil;
 
+    @Operation(
+            summary = "GitHub OAuth 인증 URL 조회",
+            description = "GitHub OAuth 로그인을 시작하기 위한 인증 URL을 반환합니다. " +
+                          "프론트엔드는 이 URL로 사용자를 리다이렉트하여 GitHub 로그인을 진행합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "인증 URL 반환 성공")
+    })
     @GetMapping("/authorize-url")
     public ResponseEntity<ResponseDto<Map<String, String>>> getAuthorizeUrl() {
         String url = "https://github.com/login/oauth/authorize"
@@ -37,6 +51,17 @@ public class GitHubOauthController {
         return ResponseEntity.ok(HttpUtil.success("authorize url", Map.of("url", url)));
     }
 
+    @Operation(
+            summary = "GitHub OAuth 연동",
+            description = "GitHub OAuth 콜백으로 전달받은 code를 사용해 GitHub 계정을 연동합니다. " +
+                          "연동 성공 시 사용자 Role이 API_MAKER로 승격되며, JWT가 재발급됩니다. " +
+                          "응답의 installUrl로 이동해 GitHub App을 설치해야 레포지토리 등록이 가능합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "GitHub 연동 성공 — Set-Cookie로 refresh_token 발급"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청")
+    })
     @PostMapping("/connect")
     public ResponseEntity<ResponseDto<GitHubConnectResponse>> connect(
             @CurrentUser User user,
@@ -55,6 +80,16 @@ public class GitHubOauthController {
         return ResponseEntity.ok(HttpUtil.success("github connected", response));
     }
 
+    @Operation(
+            summary = "GitHub 연결 상태 조회",
+            description = "현재 로그인한 사용자의 GitHub 연동 상태를 조회합니다. " +
+                          "appInstalled가 false이면 GitHub App 설치가 필요합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "연결 상태 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "GitHub 연동 내역 없음")
+    })
     @GetMapping("/connection")
     public ResponseEntity<ResponseDto<GitHubConnectionResponse>> getConnection(@CurrentUser User user) {
         GitHubConnectionResponse response = gitHubConnectionQueryService.getConnection(user.getUserId());

--- a/app/src/main/java/com/example/bssm_dev/domain/github/controller/GitHubRepositoryController.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/controller/GitHubRepositoryController.java
@@ -11,6 +11,12 @@ import com.example.bssm_dev.domain.github.dto.response.RegisteredRepoResponse;
 import com.example.bssm_dev.domain.github.service.GitHubRepositoryQueryService;
 import com.example.bssm_dev.domain.github.service.GitHubRepositoryService;
 import com.example.bssm_dev.domain.user.model.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -19,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "GitHub Repository", description = "GitHub 레포지토리 등록 및 관리 API")
 @RestController
 @RequestMapping("/github/repositories")
 @RequiredArgsConstructor
@@ -27,9 +34,18 @@ public class GitHubRepositoryController {
     private final GitHubRepositoryService gitHubRepositoryService;
     private final GitHubRepositoryQueryService gitHubRepositoryQueryService;
 
-    /**
-     * GitHub App이 설치된 레포지토리 목록 조회 (GitHub API 실시간 조회)
-     */
+    @Operation(
+            summary = "GitHub App이 설치된 레포지토리 목록 조회",
+            description = "GitHub App이 설치된 레포지토리 목록을 GitHub API에서 실시간으로 조회합니다. " +
+                          "레포지토리를 등록하려면 먼저 GitHub App이 설치되어 있어야 합니다. " +
+                          "GitHub App 미설치 시 400 에러가 반환됩니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "레포지토리 목록 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "GitHub App이 설치되지 않음"),
+            @ApiResponse(responseCode = "404", description = "GitHub 연동 내역 없음")
+    })
     @GetMapping("/available")
     public ResponseEntity<ResponseDto<List<GitHubRepoItem>>> getAvailableRepositories(
             @CurrentUser User user
@@ -38,22 +54,38 @@ public class GitHubRepositoryController {
         return ResponseEntity.ok(HttpUtil.success("available repositories", repos));
     }
 
-    /**
-     * 특정 레포지토리의 브랜치 목록 조회
-     */
+    @Operation(
+            summary = "레포지토리 브랜치 목록 조회",
+            description = "특정 레포지토리의 브랜치 목록을 GitHub API에서 실시간으로 조회합니다. " +
+                          "레포지토리 등록 시 브랜치 선택에 사용합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "브랜치 목록 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "GitHub App이 설치되지 않음"),
+            @ApiResponse(responseCode = "404", description = "GitHub 연동 내역 없음")
+    })
     @GetMapping("/{owner}/{repo}/branches")
     public ResponseEntity<ResponseDto<List<GitHubBranchItem>>> getBranches(
             @CurrentUser User user,
+            @Parameter(description = "레포지토리 소유자 (GitHub 사용자명 또는 조직명)", example = "BSSM-Developers")
             @PathVariable String owner,
+            @Parameter(description = "레포지토리 이름", example = "BSSM_DEVELOPERS_BE")
             @PathVariable String repo
     ) {
         List<GitHubBranchItem> branches = gitHubRepositoryQueryService.getBranches(user.getUserId(), owner, repo);
         return ResponseEntity.ok(HttpUtil.success("branches", branches));
     }
 
-    /**
-     * 등록된 레포지토리 목록 조회 (DB)
-     */
+    @Operation(
+            summary = "등록된 레포지토리 목록 조회",
+            description = "현재 사용자가 등록한 레포지토리 목록을 DB에서 조회합니다. " +
+                          "등록된 레포지토리에 push 이벤트가 발생하면 엔드포인트가 자동 동기화됩니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "등록된 레포지토리 목록 조회 성공")
+    })
     @GetMapping
     public ResponseEntity<ResponseDto<List<RegisteredRepoResponse>>> getRegisteredRepositories(
             @CurrentUser User user
@@ -62,9 +94,19 @@ public class GitHubRepositoryController {
         return ResponseEntity.ok(HttpUtil.success("registered repositories", repos));
     }
 
-    /**
-     * 레포지토리 등록 (App이 설치된 레포만 가능)
-     */
+    @Operation(
+            summary = "레포지토리 등록",
+            description = "GitHub App이 설치된 레포지토리를 등록합니다. " +
+                          "등록된 레포지토리는 push 이벤트 수신 대상이 되며, 코드 변경 시 엔드포인트가 자동으로 파싱·동기화됩니다. " +
+                          "GitHub App이 접근 권한을 가진 레포지토리만 등록 가능합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "레포지토리 등록 성공"),
+            @ApiResponse(responseCode = "400", description = "GitHub App이 설치되지 않음"),
+            @ApiResponse(responseCode = "403", description = "GitHub App이 해당 레포지토리에 접근 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "GitHub 연동 내역 없음")
+    })
     @PostMapping
     public ResponseEntity<ResponseDto<RegisteredRepoResponse>> register(
             @CurrentUser User user,
@@ -74,24 +116,43 @@ public class GitHubRepositoryController {
         return ResponseEntity.status(HttpStatus.CREATED).body(HttpUtil.success("repository registered", response));
     }
 
-    /**
-     * 레포지토리 등록 해제
-     */
+    @Operation(
+            summary = "레포지토리 등록 해제",
+            description = "등록된 레포지토리를 해제합니다. " +
+                          "해제 후에는 해당 레포지토리의 push 이벤트를 더 이상 처리하지 않습니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "레포지토리 등록 해제 성공"),
+            @ApiResponse(responseCode = "403", description = "본인 레포지토리가 아님"),
+            @ApiResponse(responseCode = "404", description = "등록된 레포지토리를 찾을 수 없음")
+    })
     @DeleteMapping("/{repoId}")
     public ResponseEntity<ResponseDto<Void>> delete(
             @CurrentUser User user,
+            @Parameter(description = "등록된 레포지토리 ID", example = "1")
             @PathVariable Long repoId
     ) {
         gitHubRepositoryService.delete(user.getUserId(), repoId);
         return ResponseEntity.ok(HttpUtil.success("repository unregistered"));
     }
 
-    /**
-     * 레포지토리에서 AST 파싱된 엔드포인트 목록 조회
-     */
+    @Operation(
+            summary = "레포지토리 AST 파싱 엔드포인트 목록 조회",
+            description = "등록된 레포지토리에서 AST로 분석된 현재 유효한 엔드포인트 목록을 조회합니다. " +
+                          "문서 작성 시 API 페이지에 등록 가능한 엔드포인트는 이 목록에 있는 것만 허용됩니다. " +
+                          "push 이벤트가 발생할 때마다 자동으로 갱신됩니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "파싱된 엔드포인트 목록 조회 성공"),
+            @ApiResponse(responseCode = "403", description = "본인 레포지토리가 아님"),
+            @ApiResponse(responseCode = "404", description = "등록된 레포지토리를 찾을 수 없음")
+    })
     @GetMapping("/{repoId}/parsed-endpoints")
     public ResponseEntity<ResponseDto<List<ParsedEndpointResponse>>> getParsedEndpoints(
             @CurrentUser User user,
+            @Parameter(description = "등록된 레포지토리 ID", example = "1")
             @PathVariable Long repoId
     ) {
         List<ParsedEndpointResponse> endpoints = gitHubRepositoryQueryService.getParsedEndpoints(user.getUserId(), repoId);

--- a/app/src/main/java/com/example/bssm_dev/domain/github/controller/GitHubWebhookController.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/controller/GitHubWebhookController.java
@@ -1,10 +1,17 @@
 package com.example.bssm_dev.domain.github.controller;
 
 import com.example.bssm_dev.domain.github.service.GitHubWebhookService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "GitHub Webhook", description = "GitHub App에서 수신하는 웹훅 이벤트 처리 API")
 @RestController
 @RequestMapping("/webhook/github")
 @RequiredArgsConstructor
@@ -12,9 +19,26 @@ public class GitHubWebhookController {
 
     private final GitHubWebhookService gitHubWebhookService;
 
+    @Operation(
+            summary = "GitHub 웹훅 수신",
+            description = "GitHub App에서 발생한 웹훅 이벤트를 수신하여 처리합니다.\n\n" +
+                          "**처리하는 이벤트:**\n" +
+                          "- `installation` (created): GitHub App 설치 완료 → installationId 저장\n" +
+                          "- `installation` (deleted): GitHub App 제거 → installationId 초기화\n" +
+                          "- `push`: 등록된 레포지토리에 코드 push → endpoint-parser로 AST 분석 후 엔드포인트 자동 동기화\n\n" +
+                          "**보안:** X-Hub-Signature-256 헤더를 HMAC-SHA256으로 검증합니다. 서명이 일치하지 않으면 요청을 거부합니다.\n\n" +
+                          "이 API는 GitHub에서만 호출하며, 직접 호출하지 않습니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "웹훅 이벤트 처리 성공"),
+            @ApiResponse(responseCode = "401", description = "웹훅 시그니처 검증 실패")
+    })
+    @SecurityRequirements
     @PostMapping
     public ResponseEntity<Void> receive(
+            @Parameter(description = "GitHub 이벤트 종류 (installation, push 등)", example = "push")
             @RequestHeader("X-GitHub-Event") String event,
+            @Parameter(description = "HMAC-SHA256 서명 (sha256={hex})", example = "sha256=abc123...")
             @RequestHeader("X-Hub-Signature-256") String signature,
             @RequestBody String payload
     ) {

--- a/app/src/main/java/com/example/bssm_dev/domain/github/dto/request/GitHubConnectRequest.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/dto/request/GitHubConnectRequest.java
@@ -1,5 +1,9 @@
 package com.example.bssm_dev.domain.github.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "GitHub OAuth 연동 요청")
 public record GitHubConnectRequest(
+        @Schema(description = "GitHub OAuth 콜백으로 전달받은 인증 코드", example = "abc123def456")
         String code
 ) {}

--- a/app/src/main/java/com/example/bssm_dev/domain/github/dto/request/RegisterGitHubRepoRequest.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/dto/request/RegisterGitHubRepoRequest.java
@@ -1,10 +1,15 @@
 package com.example.bssm_dev.domain.github.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "레포지토리 등록 요청")
 public record RegisterGitHubRepoRequest(
+        @Schema(description = "레포지토리 전체 이름 (owner/repo 형식)", example = "BSSM-Developers/BSSM_DEVELOPERS_BE")
         @NotBlank(message = "레포지토리 이름은 필수입니다. (예: owner/repo)")
         String repoFullName,
+
+        @Schema(description = "추적할 브랜치명", example = "main")
         @NotBlank(message = "브랜치명은 필수입니다.")
         String branch
 ) {}

--- a/app/src/main/java/com/example/bssm_dev/domain/github/dto/response/GitHubBranchItem.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/dto/response/GitHubBranchItem.java
@@ -1,8 +1,13 @@
 package com.example.bssm_dev.domain.github.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "GitHub 레포지토리 브랜치")
 public record GitHubBranchItem(
+        @Schema(description = "브랜치명", example = "main")
         String name,
+
+        @Schema(description = "보호된 브랜치 여부", example = "true")
         @JsonProperty("protected") boolean isProtected
 ) {}

--- a/app/src/main/java/com/example/bssm_dev/domain/github/dto/response/GitHubConnectResponse.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/dto/response/GitHubConnectResponse.java
@@ -1,8 +1,17 @@
 package com.example.bssm_dev.domain.github.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "GitHub OAuth 연동 결과")
 public record GitHubConnectResponse(
+        @Schema(description = "연동된 GitHub 사용자명", example = "octocat")
         String githubLogin,
+
+        @Schema(description = "GitHub App 설치 URL — 이 URL로 이동해 App을 설치해야 레포지토리 등록이 가능합니다",
+                example = "https://github.com/apps/bssm-dev/installations/new")
         String installUrl,
+
+        @Schema(description = "재발급된 JWT Access Token")
         String accessToken
 ) {
     public static GitHubConnectResponse of(String githubLogin, String installUrl, String accessToken) {

--- a/app/src/main/java/com/example/bssm_dev/domain/github/dto/response/GitHubConnectionResponse.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/dto/response/GitHubConnectionResponse.java
@@ -1,8 +1,16 @@
 package com.example.bssm_dev.domain.github.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "GitHub 연결 상태")
 public record GitHubConnectionResponse(
+        @Schema(description = "연동된 GitHub 사용자명", example = "octocat")
         String githubLogin,
+
+        @Schema(description = "GitHub App Installation ID — null이면 App 미설치 상태", example = "12345678")
         Long installationId,
+
+        @Schema(description = "GitHub App 설치 여부 — false이면 레포지토리 등록 불가", example = "true")
         boolean appInstalled
 ) {
     public static GitHubConnectionResponse of(String githubLogin, Long installationId) {

--- a/app/src/main/java/com/example/bssm_dev/domain/github/dto/response/GitHubRepoItem.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/dto/response/GitHubRepoItem.java
@@ -1,10 +1,19 @@
 package com.example.bssm_dev.domain.github.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "GitHub App이 접근 가능한 레포지토리")
 public record GitHubRepoItem(
+        @Schema(description = "GitHub 레포지토리 ID", example = "123456789")
         Long id,
+
+        @Schema(description = "레포지토리 전체 이름 (owner/repo)", example = "BSSM-Developers/BSSM_DEVELOPERS_BE")
         String full_name,
+
+        @Schema(description = "레포지토리 이름", example = "BSSM_DEVELOPERS_BE")
         String name,
+
+        @Schema(description = "비공개 레포지토리 여부", example = "false")
         @JsonProperty("private") boolean isPrivate
 ) {}

--- a/app/src/main/java/com/example/bssm_dev/domain/github/dto/response/ParsedEndpointResponse.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/dto/response/ParsedEndpointResponse.java
@@ -1,9 +1,14 @@
 package com.example.bssm_dev.domain.github.dto.response;
 
 import com.example.bssm_dev.domain.api.model.Api;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "AST 파싱으로 감지된 엔드포인트")
 public record ParsedEndpointResponse(
+        @Schema(description = "HTTP 메서드", example = "GET")
         String method,
+
+        @Schema(description = "엔드포인트 경로", example = "/health")
         String endpoint
 ) {
     public static ParsedEndpointResponse from(Api api) {

--- a/app/src/main/java/com/example/bssm_dev/domain/github/dto/response/RegisteredRepoResponse.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/dto/response/RegisteredRepoResponse.java
@@ -1,11 +1,20 @@
 package com.example.bssm_dev.domain.github.dto.response;
 
 import com.example.bssm_dev.domain.github.model.GitHubRepository;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "등록된 레포지토리 정보")
 public record RegisteredRepoResponse(
+        @Schema(description = "등록된 레포지토리 ID", example = "1")
         Long id,
+
+        @Schema(description = "레포지토리 전체 이름 (owner/repo)", example = "BSSM-Developers/BSSM_DEVELOPERS_BE")
         String repoFullName,
+
+        @Schema(description = "추적 중인 브랜치명", example = "main")
         String branch,
+
+        @Schema(description = "레포지토리 URL", example = "https://github.com/BSSM-Developers/BSSM_DEVELOPERS_BE")
         String repositoryUrl
 ) {
     public static RegisteredRepoResponse from(GitHubRepository repo) {

--- a/app/src/main/java/com/example/bssm_dev/global/config/OpenApiConfig.java
+++ b/app/src/main/java/com/example/bssm_dev/global/config/OpenApiConfig.java
@@ -1,0 +1,29 @@
+package com.example.bssm_dev.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "BSSM Developers API",
+                version = "0.1.43",
+                description = "BSSM Developers 플랫폼 API 명세"
+        ),
+        security = @SecurityRequirement(name = "bearerAuth")
+)
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT",
+        in = SecuritySchemeIn.HEADER,
+        description = "로그인 후 발급된 Access Token을 입력하세요."
+)
+public class OpenApiConfig {
+}


### PR DESCRIPTION
- OpenApiConfig: JWT bearerAuth SecurityScheme 및 API 기본 정보 설정
- GitHubOauthController: @Tag, @Operation, @ApiResponses 추가
- GitHubRepositoryController: @Tag, @Operation, @Parameter, @ApiResponses 추가
- GitHubWebhookController: @Tag, @Operation, @SecurityRequirements(인증 제외) 추가
- GitHub 관련 요청/응답 DTO 전체 @Schema 추가