### PR TITLE
fix :: GitHub installation webhook org 설치 처리 및 응답 보안 개선

### DIFF
--- a/app/src/main/java/com/example/bssm_dev/domain/github/dto/response/GitHubConnectionResponse.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/dto/response/GitHubConnectionResponse.java
@@ -7,13 +7,10 @@ public record GitHubConnectionResponse(
         @Schema(description = "연동된 GitHub 사용자명", example = "octocat")
         String githubLogin,
 
-        @Schema(description = "GitHub App Installation ID — null이면 App 미설치 상태", example = "12345678")
-        Long installationId,
-
         @Schema(description = "GitHub App 설치 여부 — false이면 레포지토리 등록 불가", example = "true")
         boolean appInstalled
 ) {
     public static GitHubConnectionResponse of(String githubLogin, Long installationId) {
-        return new GitHubConnectionResponse(githubLogin, installationId, installationId != null);
+        return new GitHubConnectionResponse(githubLogin, installationId != null);
     }
 }

--- a/app/src/main/java/com/example/bssm_dev/domain/github/service/GitHubWebhookService.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/service/GitHubWebhookService.java
@@ -50,8 +50,17 @@ public class GitHubWebhookService {
             String action = root.path("action").asText();
             Long installationId = root.path("installation").path("id").asLong();
             Long githubUserId = root.path("installation").path("account").path("id").asLong();
+            String accountLogin = root.path("installation").path("account").path("login").asText();
+            String accountType = root.path("installation").path("account").path("type").asText();
+            Long senderGithubId = root.path("sender").path("id").asLong();
 
-            gitHubConnectionRepository.findByGithubId(githubUserId).ifPresent(connection -> {
+            log.info("github installation event - action={}, installationId={}, accountId={}, accountLogin={}, accountType={}, senderGithubId={}",
+                    action, installationId, githubUserId, accountLogin, accountType, senderGithubId);
+
+            Long lookupId = "Organization".equals(accountType) ? senderGithubId : githubUserId;
+            log.info("github installation lookup - lookupId={}", lookupId);
+
+            gitHubConnectionRepository.findByGithubId(lookupId).ifPresentOrElse(connection -> {
                 if (ACTION_CREATED.equals(action)) {
                     connection.updateInstallationId(installationId);
                     gitHubConnectionRepository.save(connection);
@@ -61,7 +70,7 @@ public class GitHubWebhookService {
                     gitHubConnectionRepository.save(connection);
                     log.info("github app uninstalled - githubLogin={}", connection.getGithubLogin());
                 }
-            });
+            }, () -> log.warn("github installation event - no connection found for githubId={}", lookupId));
         } catch (Exception e) {
             log.error("failed to handle github installation event", e);
         }


### PR DESCRIPTION
- installation 이벤트 수신 시 account type이 Organization이면 sender.id(개인 계정)로 fallback하여 GitHubConnection 조회
- 디버그 로그 추가 (accountId, accountType, senderGithubId)
- GitHubConnectionResponse에서 installationId 필드 제거 (내부 식별자 노출 방지)