### PR TITLE
feat :: parsed-endpoints를 GitHub repo ID 기반 실시간 파싱으로 변경

### DIFF
--- a/app/src/main/java/com/example/bssm_dev/domain/github/controller/GitHubRepositoryController.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/controller/GitHubRepositoryController.java
@@ -110,21 +110,26 @@ public class GitHubRepositoryController {
 
     @Operation(
             summary = "레포지토리 AST 파싱 엔드포인트 목록 조회",
-            description = "등록된 레포지토리에서 AST로 분석된 현재 유효한 엔드포인트 목록을 조회합니다.",
+            description = "GitHub 레포지토리를 AST로 실시간 분석해 엔드포인트 목록을 반환합니다. " +
+                          "githubRepoId는 /github/repositories/available 응답의 id 필드를 사용하세요.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "파싱된 엔드포인트 목록 조회 성공"),
-            @ApiResponse(responseCode = "403", description = "본인 레포지토리가 아님"),
-            @ApiResponse(responseCode = "404", description = "등록된 레포지토리를 찾을 수 없음")
+            @ApiResponse(responseCode = "400", description = "GitHub App 미설치"),
+            @ApiResponse(responseCode = "404", description = "GitHub 연동 내역 없음")
     })
-    @GetMapping("/{repoId}/parsed-endpoints")
+    @GetMapping("/{githubRepoId}/parsed-endpoints")
     public ResponseEntity<ResponseDto<List<ParsedEndpointResponse>>> getParsedEndpoints(
             @CurrentUser User user,
-            @Parameter(description = "등록된 레포지토리 ID", example = "1")
-            @PathVariable Long repoId
+            @Parameter(description = "GitHub 레포지토리 ID (available 응답의 id)", example = "1132804732")
+            @PathVariable Long githubRepoId,
+            @Parameter(description = "브랜치명", example = "main")
+            @RequestParam String repoFullName,
+            @Parameter(description = "레포지토리 full_name (owner/repo)", example = "Denormalization/FE")
+            @RequestParam String branch
     ) {
-        List<ParsedEndpointResponse> endpoints = gitHubRepositoryQueryService.getParsedEndpoints(user.getUserId(), repoId);
+        List<ParsedEndpointResponse> endpoints = gitHubRepositoryQueryService.getParsedEndpoints(user.getUserId(), repoFullName, branch);
         return ResponseEntity.ok(HttpUtil.success("parsed endpoints", endpoints));
     }
 }

--- a/app/src/main/java/com/example/bssm_dev/domain/github/dto/response/ParsedEndpointResponse.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/dto/response/ParsedEndpointResponse.java
@@ -14,4 +14,8 @@ public record ParsedEndpointResponse(
     public static ParsedEndpointResponse from(Api api) {
         return new ParsedEndpointResponse(api.getMethod(), api.getEndpoint());
     }
+
+    public static ParsedEndpointResponse from(EndpointParseResponse.ParsedEndpoint parsed) {
+        return new ParsedEndpointResponse(parsed.method(), parsed.path());
+    }
 }

--- a/app/src/main/java/com/example/bssm_dev/domain/github/service/GitHubRepositoryQueryService.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/service/GitHubRepositoryQueryService.java
@@ -1,6 +1,8 @@
 package com.example.bssm_dev.domain.github.service;
 
 import com.example.bssm_dev.domain.api.repository.ApiRepository;
+import com.example.bssm_dev.domain.github.dto.request.EndpointParseRequest;
+import com.example.bssm_dev.domain.github.dto.response.EndpointParseResponse;
 import com.example.bssm_dev.domain.github.dto.response.GitHubBranchItem;
 import com.example.bssm_dev.domain.github.dto.response.GitHubRepoItem;
 import com.example.bssm_dev.domain.github.dto.response.ParsedEndpointResponse;
@@ -13,6 +15,8 @@ import com.example.bssm_dev.domain.github.model.GitHubConnection;
 import com.example.bssm_dev.domain.github.model.GitHubRepository;
 import com.example.bssm_dev.domain.github.repository.GitHubConnectionRepository;
 import com.example.bssm_dev.domain.github.repository.GitHubRepositoryRepository;
+import com.example.bssm_dev.global.component.GitHubInstallationTokenProvider;
+import com.example.bssm_dev.global.feign.EndpointParserFeign;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +31,8 @@ public class GitHubRepositoryQueryService {
     private final GitHubRepositoryRepository gitHubRepositoryRepository;
     private final GitHubApiService gitHubApiService;
     private final ApiRepository apiRepository;
+    private final GitHubInstallationTokenProvider installationTokenProvider;
+    private final EndpointParserFeign endpointParserFeign;
 
     @Transactional(readOnly = true)
     public List<RegisteredRepoResponse> getRegisteredRepositories(Long userId) {
@@ -57,16 +63,16 @@ public class GitHubRepositoryQueryService {
         return repo;
     }
 
-    @Transactional(readOnly = true)
-    public List<ParsedEndpointResponse> getParsedEndpoints(Long userId, Long repoId) {
-        GitHubRepository repo = gitHubRepositoryRepository.findById(repoId)
-                .orElseThrow(GitHubRepositoryNotFoundException::raise);
-
-        if (!repo.isOwnedBy(userId)) {
-            throw GitHubRepositoryUnauthorizedException.raise();
+    public List<ParsedEndpointResponse> getParsedEndpoints(Long userId, String repoFullName, String branch) {
+        Long installationId = getInstallationIdOrThrow(userId);
+        String installationToken = installationTokenProvider.getInstallationToken(installationId);
+        EndpointParseResponse parsed = endpointParserFeign.parse(
+                new EndpointParseRequest(repoFullName, branch, installationToken)
+        );
+        if (parsed == null || parsed.endpoints() == null) {
+            return List.of();
         }
-
-        return apiRepository.findAllByGithubRepositoryIdAndIsCurrentTrue(repoId).stream()
+        return parsed.endpoints().stream()
                 .map(ParsedEndpointResponse::from)
                 .toList();
     }


### PR DESCRIPTION
- DB 등록 없이 githubRepoId + repoFullName + branch로 endpoint-parser 직접 호출
- docs 생성 전 엔드포인트 미리 조회 가능
- ParsedEndpointResponse에 EndpointParseResponse.ParsedEndpoint 팩토리 추가