### PR TITLE
fix :: GitHub 브랜치 전체 페이지네이션 조회 추가

### DIFF
--- a/app/src/main/java/com/example/bssm_dev/domain/github/service/GitHubApiService.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/github/service/GitHubApiService.java
@@ -7,6 +7,7 @@ import com.example.bssm_dev.global.feign.GitHubInstallationApiFeign;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -18,6 +19,7 @@ import java.util.List;
 public class GitHubApiService {
 
     private static final String GITHUB_API_ACCEPT = "application/vnd.github+json";
+    private static final int BRANCHES_PER_PAGE = 100;
 
     private final GitHubInstallationTokenProvider installationTokenProvider;
     private final GitHubInstallationApiFeign gitHubInstallationApiFeign;
@@ -31,7 +33,21 @@ public class GitHubApiService {
 
     public List<GitHubBranchItem> getBranches(Long installationId, String owner, String repo) {
         String token = bearerToken(installationTokenProvider.getInstallationToken(installationId));
-        return gitHubInstallationApiFeign.getBranches(token, GITHUB_API_ACCEPT, owner, repo);
+        List<GitHubBranchItem> all = new ArrayList<>();
+        int page = 1;
+        while (true) {
+            List<GitHubBranchItem> batch = gitHubInstallationApiFeign
+                    .getBranches(token, GITHUB_API_ACCEPT, owner, repo, BRANCHES_PER_PAGE, page);
+            if (batch == null || batch.isEmpty()) {
+                break;
+            }
+            all.addAll(batch);
+            if (batch.size() < BRANCHES_PER_PAGE) {
+                break;
+            }
+            page++;
+        }
+        return all;
     }
 
     private String bearerToken(String token) {

--- a/app/src/main/java/com/example/bssm_dev/global/feign/GitHubInstallationApiFeign.java
+++ b/app/src/main/java/com/example/bssm_dev/global/feign/GitHubInstallationApiFeign.java
@@ -6,6 +6,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
@@ -23,6 +24,8 @@ public interface GitHubInstallationApiFeign {
             @RequestHeader("Authorization") String installationToken,
             @RequestHeader("Accept") String accept,
             @PathVariable String owner,
-            @PathVariable String repo
+            @PathVariable String repo,
+            @RequestParam("per_page") int perPage,
+            @RequestParam("page") int page
     );
 }


### PR DESCRIPTION
GitHub API 기본값(30개)으로 브랜치가 누락되는 문제 수정.
per_page=100으로 전체 페이지를 순회해 모든 브랜치를 수집한다.