### PR TITLE
feat(api): add webhook endpoint to block API token

### DIFF
--- a/app/src/main/java/com/example/bssm_dev/domain/api/controller/command/WebhookApiTokenController.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/controller/command/WebhookApiTokenController.java
@@ -1,0 +1,25 @@
+package com.example.bssm_dev.domain.api.controller.command;
+
+import com.example.bssm_dev.common.dto.ResponseDto;
+import com.example.bssm_dev.common.util.HttpUtil;
+import com.example.bssm_dev.domain.api.service.command.ApiTokenWebhookCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/webhook/api/token")
+public class WebhookApiTokenController {
+    private final ApiTokenWebhookCommandService apiTokenWebhookCommandService;
+
+    @PostMapping("/{tokenId}/block")
+    public ResponseEntity<ResponseDto<Void>> blockApiToken(
+            @RequestHeader("X-Webhook-Secret") String webhookSecret,
+            @PathVariable("tokenId") Long tokenId
+    ) {
+        apiTokenWebhookCommandService.blockApiToken(webhookSecret, tokenId);
+        ResponseDto<Void> responseDto = HttpUtil.success("Successfully blocked API token");
+        return ResponseEntity.ok(responseDto);
+    }
+}

--- a/app/src/main/java/com/example/bssm_dev/domain/api/exception/InvalidWebhookSecretException.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/exception/InvalidWebhookSecretException.java
@@ -1,0 +1,18 @@
+package com.example.bssm_dev.domain.api.exception;
+
+import com.example.bssm_dev.exception.ErrorCode;
+import com.example.bssm_dev.exception.GlobalException;
+
+public class InvalidWebhookSecretException extends GlobalException {
+    private InvalidWebhookSecretException() {
+        super(ErrorCode.INVALID_WEBHOOK_SECRET);
+    }
+
+    private static class Holder {
+        private static final InvalidWebhookSecretException INSTANCE = new InvalidWebhookSecretException();
+    }
+
+    public static InvalidWebhookSecretException raise() {
+        return Holder.INSTANCE;
+    }
+}

--- a/app/src/main/java/com/example/bssm_dev/domain/api/model/ApiToken.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/model/ApiToken.java
@@ -126,4 +126,8 @@ public class ApiToken {
     public void unblock() {
         this.state = ApiTokenState.NORMAL;
     }
+
+    public void block() {
+        this.state = ApiTokenState.BLOCKED;
+    }
 }

--- a/app/src/main/java/com/example/bssm_dev/domain/api/service/command/ApiTokenWebhookCommandService.java
+++ b/app/src/main/java/com/example/bssm_dev/domain/api/service/command/ApiTokenWebhookCommandService.java
@@ -1,0 +1,37 @@
+package com.example.bssm_dev.domain.api.service.command;
+
+import com.example.bssm_dev.domain.api.exception.ApiTokenNotFoundException;
+import com.example.bssm_dev.domain.api.exception.InvalidWebhookSecretException;
+import com.example.bssm_dev.domain.api.model.ApiToken;
+import com.example.bssm_dev.domain.api.model.type.ApiTokenState;
+import com.example.bssm_dev.domain.api.repository.ApiTokenRepository;
+import com.example.bssm_dev.global.config.properties.WebhookProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional("transactionManager")
+public class ApiTokenWebhookCommandService {
+    private final ApiTokenRepository apiTokenRepository;
+    private final WebhookProperties webhookProperties;
+
+    public void blockApiToken(String webhookSecret, Long tokenId) {
+        validateWebhookSecret(webhookSecret);
+
+        ApiToken apiToken = apiTokenRepository.findById(tokenId)
+                .orElseThrow(ApiTokenNotFoundException::raise);
+
+        if (apiToken.getState() != ApiTokenState.BLOCKED) {
+            apiToken.block();
+            apiTokenRepository.save(apiToken);
+        }
+    }
+
+    private void validateWebhookSecret(String webhookSecret) {
+        if (webhookSecret == null || !webhookSecret.equals(webhookProperties.getSecret())) {
+            throw InvalidWebhookSecretException.raise();
+        }
+    }
+}

--- a/app/src/main/java/com/example/bssm_dev/exception/ErrorCode.java
+++ b/app/src/main/java/com/example/bssm_dev/exception/ErrorCode.java
@@ -68,7 +68,8 @@ public enum ErrorCode {
     GITHUB_WEBHOOK_SIGNATURE_INVALID(403, "GitHub 웹훅 서명이 유효하지 않습니다."),
     GITHUB_INSTALLATION_TOKEN_FAIL(502, "GitHub App 설치 토큰 발급에 실패했습니다."),
     GITHUB_REPOSITORY_NOT_FOUND(404, "등록된 GitHub 레포지토리를 찾을 수 없습니다."),
-    GITHUB_REPOSITORY_UNAUTHORIZED(403, "해당 GitHub 레포지토리에 접근할 권한이 없습니다.");
+    GITHUB_REPOSITORY_UNAUTHORIZED(403, "해당 GitHub 레포지토리에 접근할 권한이 없습니다."),
+    INVALID_WEBHOOK_SECRET(401, "유효하지 않은 웹훅 시크릿입니다.");
 
 
     private final int statusCode;

--- a/app/src/main/java/com/example/bssm_dev/global/config/SecurityConfig.java
+++ b/app/src/main/java/com/example/bssm_dev/global/config/SecurityConfig.java
@@ -109,6 +109,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/**").permitAll()
                         .requestMatchers("/webhook/github").permitAll()
+                        .requestMatchers("/webhook/api/**").permitAll()
                         .requestMatchers("/signup/me").permitAll()
                         .requestMatchers("/signup/*/purpose").permitAll()
                         .requestMatchers("/signup/**").access(requiresAdmin)

--- a/app/src/main/java/com/example/bssm_dev/global/config/properties/WebhookProperties.java
+++ b/app/src/main/java/com/example/bssm_dev/global/config/properties/WebhookProperties.java
@@ -1,0 +1,10 @@
+package com.example.bssm_dev.global.config.properties;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties("webhook")
+public class WebhookProperties {
+    private String secret;
+}


### PR DESCRIPTION
POST /webhook/api/token/{tokenId}/block authenticated via X-Webhook-Secret header for ntfy webhook integration. Idempotent — silently skips already-blocked tokens.